### PR TITLE
Add new database.conf option 'database chunk size'

### DIFF
--- a/common/etc/database.conf
+++ b/common/etc/database.conf
@@ -12,3 +12,9 @@ database name       = warewulf
 # update the Warewulf database.
 database user       = wwuser
 database password   = 
+
+# Set the max_allowed_packet in bytes, which also defines the chunk size 
+# used to upload or download the VNFS to the database. By default this
+# value is defined from the database. Only set this if you need to override
+# this value.
+# database chunk size = 16777216

--- a/common/lib/Warewulf/DataStore/SQL/MySQL.pm
+++ b/common/lib/Warewulf/DataStore/SQL/MySQL.pm
@@ -149,6 +149,10 @@ chunk_size()
 {
     my $self = shift;
     my $max_allowed_packet;
+    my $config = Warewulf::Config->new("database.conf");
+    if ($max_allowed_packet = $config->get("database chunk size")) {
+        return $max_allowed_packet;
+    }
 
     if (! $self->{"DBH"}) {
         $self->init();


### PR DESCRIPTION
Adds a new database.conf option 'database chunk size' to override of database's max_allowed_packet. This is needed in our case as our MySQL db has a very large value set, 1073741824. With this large value any time Warewulf pulls an image it uses a considerable amount of memory on the DB and the Warewulf server.