### PR TITLE
Fixed /sbin/init symlink check.

### DIFF
--- a/provision/initramfs/capabilities/transport-http/wwgetvnfs
+++ b/provision/initramfs/capabilities/transport-http/wwgetvnfs
@@ -33,7 +33,7 @@ while true; do
         WGETEXIT=$?
 
         wait
-        if [ -f "$NEWROOT/sbin/init" -o -f "$NEWROOT`readlink $NEWROOT/sbin/init`" ]; then
+        if [ -f "$NEWROOT/sbin/init" -o -h "$NEWROOT/sbin/init" ]; then
             echo
             exit 0
 	fi

--- a/provision/initramfs/init
+++ b/provision/initramfs/init
@@ -351,7 +351,7 @@ if [ -n "$WWPOSTSHELL" -a "$WWPOSTSHELL" != "0" ]; then
     setsid /bin/cttyhack /bin/sh
 fi
 
-if [ -e "$NEWROOT/sbin/init" ]; then
+if [ -e "$NEWROOT/sbin/init" -o -h "$NEWROOT/sbin/init" ]; then
     msg_white "Stopping syslogd: "
     if killall syslogd >/dev/null 2>&1; then
         wwsuccess


### PR DESCRIPTION
2062c90c68cd8590c8772179b9afe688a80f1f09 makes it buggy again!!! The reason is that

    [ -e "$NEWROOT/sbin/init" ]

follows symlinks. So the test will fail. You need:

    [ -e "$NEWROOT/sbin/init" -o -L "$NEWROOT/sbin/init" ]

I would also suggest changing `provision/initramfs/capabilities/transport-http/wwgetvnfs` for consistency. I have created another pull request with a fix.