### PR TITLE
Check $NEWROOT/sbin/init status

### DIFF
--- a/provision/initramfs/capabilities/transport-http/wwgetvnfs
+++ b/provision/initramfs/capabilities/transport-http/wwgetvnfs
@@ -33,7 +33,7 @@ while true; do
         WGETEXIT=$?
 
         wait
-        if [ -f "$NEWROOT/sbin/init" -o -h "$NEWROOT/sbin/init" ]; then
+        if [ -x "$NEWROOT/sbin/init" -o -h "$NEWROOT/sbin/init" ]; then
             echo
             exit 0
 	fi

--- a/provision/initramfs/init
+++ b/provision/initramfs/init
@@ -351,7 +351,7 @@ if [ -n "$WWPOSTSHELL" -a "$WWPOSTSHELL" != "0" ]; then
     setsid /bin/cttyhack /bin/sh
 fi
 
-if [ -e "$NEWROOT/sbin/init" -o -h "$NEWROOT/sbin/init" ]; then
+if [ -x "$NEWROOT/sbin/init" -o -h "$NEWROOT/sbin/init" ]; then
     msg_white "Stopping syslogd: "
     if killall syslogd >/dev/null 2>&1; then
         wwsuccess


### PR DESCRIPTION
Check that `$NEWROOT/sbin/init` is either executable, or a symlink. Not just that it exists.