### PR TITLE
Add postreboot provision CLI arg, and remove check for /tmp/stateful-root

### DIFF
--- a/provision/initramfs/capabilities/setup-filesystems/99-postreboot
+++ b/provision/initramfs/capabilities/setup-filesystems/99-postreboot
@@ -8,7 +8,7 @@
 #
 
 
-if [ "x$WWPOSTREBOOT" == "xyes" -a -f "/tmp/stateful-root" ]; then
+if [ "${WWPOSTREBOOT:-}" -eq 1 ]; then
     echo
     echo
     echo "Rebooting in 5 seconds..."

--- a/provision/lib/Warewulf/Module/Cli/Provision.pm
+++ b/provision/lib/Warewulf/Module/Cli/Provision.pm
@@ -93,6 +93,7 @@ help()
     $h .= "         --filedel       Remove a file to be provisioned to this node\n";
     $h .= "         --preshell      Start a shell on the node before provisioning (boolean)\n";
     $h .= "         --postshell     Start a shell on the node after provisioning (boolean)\n";
+    $h .= "         --postreboot    Reboot after provisioning instead of switch_root into VNFS (boolean)\n";
     $h .= "         --postnetdown   Shutdown the network after provisioning (boolean)\n";
     $h .= "         --bootlocal     Boot the node from the local disk (\"exit\" or \"normal\")\n";
     $h .= "         --console       Set a specific console for the kernel command line\n";
@@ -179,6 +180,7 @@ exec()
     my $opt_vnfs;
     my $opt_preshell;
     my $opt_postshell;
+    my $opt_postreboot;
     my $opt_postnetdown;
     my $opt_bootlocal;
     my @opt_master;
@@ -219,6 +221,7 @@ exec()
         'V|vnfs=s'      => \$opt_vnfs,
         'preshell=s'    => \$opt_preshell,
         'postshell=s'   => \$opt_postshell,
+        'postreboot=s'  => \$opt_postreboot,
         'postnetdown=s' => \$opt_postnetdown,
         'bootlocal=s'   => \$opt_bootlocal,
         'l|lookup=s'    => \$opt_lookup,
@@ -351,6 +354,31 @@ exec()
                     $persist_bool = 1;
                 }
                 push(@changes, sprintf("     SET: %-20s = %s\n", "POSTSHELL", 1));
+            }
+        }
+
+        if (defined($opt_postreboot)) {
+            if (uc($opt_postreboot) eq "UNDEF" or
+                uc($opt_postreboot) eq "FALSE" or
+                uc($opt_postreboot) eq "NO" or
+                uc($opt_postreboot) eq "N" or
+                $opt_postreboot == 0
+            ) {
+                foreach my $obj ($objSet->get_list()) {
+                    my $name = $obj->name() || "UNDEF";
+                    $obj->postreboot(0);
+                    &dprint("Disabling postreboot for node name: $name\n");
+                    $persist_bool = 1;
+                }
+                push(@changes, sprintf("   UNDEF: %-20s\n", "POSTREBOOT"));
+            } else {
+                foreach my $obj ($objSet->get_list()) {
+                    my $name = $obj->name() || "UNDEF";
+                    $obj->postreboot(1);
+                    &dprint("Enabling postreboot for node name: $name\n");
+                    $persist_bool = 1;
+                }
+                push(@changes, sprintf("     SET: %-20s = %s\n", "POSTREBOOT", 1));
             }
         }
 

--- a/provision/lib/Warewulf/Provision.pm
+++ b/provision/lib/Warewulf/Provision.pm
@@ -381,6 +381,29 @@ postshell()
 }
 
 
+=item postreboot($bool)
+
+Set or return the postreboot boolean
+
+=cut
+
+sub
+postreboot()
+{
+    my ($self, $bool) = @_;
+
+    if (defined($bool)) {
+        if ($bool) {
+            $self->set("postreboot", 1);
+        } else {
+            $self->del("postreboot");
+        }
+    }
+
+    return $self->get("postreboot");
+}
+
+
 =item selinux($value)
 
 Set or return SELinux support


### PR DESCRIPTION
 /tmp/stateful-root isn't being created by 20-filesystems, and I think its sane to reboot no matter what if WWPOSTREBOOT is set. Fixes one of the requests in #16.