### PR TITLE
Resolve the depmod symlink to kmod inside of the newroot

### DIFF
--- a/provision/initramfs/capabilities/provision-vnfs/70-kernelmodules
+++ b/provision/initramfs/capabilities/provision-vnfs/70-kernelmodules
@@ -2,30 +2,31 @@
 #
 # Copyright (c) 2001-2003 Gregory M. Kurtzer
 #
-# Copyright (c) 2003-2011, The Regents of the University of California,
+# Copyright (c) 2003-2017, The Regents of the University of California,
 # through Lawrence Berkeley National Laboratory (subject to receipt of any
 # required approvals from the U.S. Dept. of Energy).  All rights reserved.
 #
 
 
-KVERSION=`uname -r`
+KVERSION=$(uname -r)
 
-if [ -d "/lib/modules/$KVERSION" ]; then
-    if [ ! -d "$NEWROOT/lib/modules/$KVERSION" ]; then
-        mkdir -p $NEWROOT/lib/modules/$KVERSION
+if [ -d "/lib/modules/${KVERSION}" ]; then
+    if [ ! -d "${NEWROOT}/lib/modules/${KVERSION}" ]; then
+        mkdir -p "${NEWROOT}/lib/modules/${KVERSION}"
     fi
-    cp -r /lib/modules/$KVERSION/* $NEWROOT/lib/modules/$KVERSION
+    cp -r /lib/modules/"${KVERSION}"/* "${NEWROOT}/lib/modules/${KVERSION}/"
 fi
 
-if [ -d "/lib/firmware/$KVERSION" ]; then
-    if [ ! -d "$NEWROOT/lib/firmware/$KVERSION" ]; then
-        mkdir -p $NEWROOT/lib/firmware/$KVERSION
+if [ -d "/lib/firmware/${KVERSION}" ]; then
+    if [ ! -d "${NEWROOT}/lib/firmware/${KVERSION}" ]; then
+        mkdir -p "${NEWROOT}/lib/firmware/${KVERSION}"
     fi
-    cp -r /lib/firmware/$KVERSION/* $NEWROOT/lib/firmware/$KVERSION
+    cp -r /lib/firmware/"${KVERSION}"/* "${NEWROOT}/lib/firmware/${KVERSION}/"
 fi
 
-if [ -x "$NEWROOT/sbin/depmod" ]; then
-    chroot $NEWROOT /sbin/depmod -a
+DEPMOD="$(chroot "${NEWROOT}" /bin/readlink -f /sbin/depmod)"
+if [ -x "${NEWROOT}${DEPMOD}" ]; then
+    chroot "${NEWROOT}" /sbin/depmod -a
 fi
 
 exit 0


### PR DESCRIPTION
Resolve the depmod symlink to kmod inside of the newroot, and check if the destination is executable. This fixes if the symlink is pointed to `/bin/kmod` (Debian) instead of `../bin/kmod` (RHEL), where the former will not resolve outside of the chroot, but the latter will. Note this approach also works if depmod isn't a symlink. Update copyright year. Cleanup quoting, curly braces, and backticks.