### PR TITLE
Bootstrap.conf - Add vfat, NLS Codepage 437, and NLS ASCII, Efivarfs, and kernel/drivers/firmware/efi/, and virtio

### DIFF
--- a/vnfs/etc/bootstrap.conf
+++ b/vnfs/etc/bootstrap.conf
@@ -3,10 +3,11 @@
 # be a list of relative paths starting from /lib/modules/`uname -r`/, or
 # specific driver names that you want to integrate.
 drivers += kernel/drivers/net/, kernel/drivers/scsi/, kernel/drivers/ata/
-drivers += kernel/drivers/message, kernel/drivers/md
-drivers += kernel/drivers/block/, kernel/drivers/usb/host/
+drivers += kernel/drivers/virtio/, kernel/drivers/message/, kernel/drivers/md/
+drivers += kernel/drivers/block/, kernel/drivers/usb/host/, kernel/drivers/firmware/efi/
 drivers += nfs, nfsd, nfs_common, nfsv4
 drivers += fuse, ext2, ext3, ext4
+drivers += fat, vfat, nls_cp437, nls_ascii, efivarfs
 drivers += ipmi_si, ipmi_devintf
 
 # Infiniband drivers and Mellanox drivers
@@ -27,7 +28,7 @@ firmware += tigon/*
 # Modules that should be called directly by /sbin/modprobe (including
 # options if any exist). Modules will be loaded in the order given, before
 # automatic hardware detection.
-modprobe += uhci-hcd, ohci-hcd, ehci-hcd, whci-hcd, isp116x-hcd, isp1362-hcd,
+modprobe += uhci-hcd, ohci-hcd, ehci-hcd, whci-hcd, isp116x-hcd, isp1362-hcd
 modprobe += xhci-hcd, sl811-hcd, sd_mod
 # modprobe += mlx4_core log_num_mtts=20 log_mtts_per_seg=6, ib_srp
 


### PR DESCRIPTION
- Updating the default bootstrap.conf to add vfat, NLS Codepage 437, and NLS ASCII, Efivarfs, and kernel/drivers/firmware/efi/ to add support for EFI ESP (/boot/efi vfat parition for EFI booting) and Efivars. Note, the NLS modules are needed in Debian but are compiled into the RHEL kernel. These are the character encoding schemes for vfat that are default for most distros and are needed for mounting vfat. 

- Virtio is useful for use within virtual machines.