### PR TITLE
Limit RPM Upgrade %post wwsh object canonicalize

### DIFF
--- a/common/warewulf-common.spec.in
+++ b/common/warewulf-common.spec.in
@@ -62,7 +62,8 @@ groupadd -r warewulf >/dev/null 2>&1 || :
 
 %post
 if [ $1 -eq 2 ] ; then
-    %{_bindir}/wwsh object canonicalize >/dev/null 2>&1 || :
+    %{_bindir}/wwsh object canonicalize -t node >/dev/null 2>&1 || :
+    %{_bindir}/wwsh object canonicalize -t file >/dev/null 2>&1 || :
 fi
 
 %post localdb

--- a/provision/warewulf-provision.spec.in
+++ b/provision/warewulf-provision.spec.in
@@ -76,6 +76,10 @@ available the included GPL software.
 %install
 %{__make} install DESTDIR=$RPM_BUILD_ROOT %{?mflags_install}
 
+%post
+if [ $1 -eq 2 ] ; then
+  echo "To update software within existing bootstraps run: wwsh bootstrap rebuild"
+fi
 
 %post server
 usermod -a -G warewulf apache >/dev/null 2>&1 || :


### PR DESCRIPTION
- Only run object canonicalize on node and file types. These are the only object types that implement canonicalize() beyond a no-op. Currently every object thats being iterated is running persist() triggering *.modify events in Warewulf/DataStore/SQL/MySQL.pm. This causes all bootstraps to be rebuilt needlessly.

- Include a note to users on upgrade of warewulf-provision rpm to run bootstrap rebuild.