### PR TITLE
Fixed warewulf-common test.

### DIFF
--- a/common/t/10-acvars.t
+++ b/common/t/10-acvars.t
@@ -38,8 +38,8 @@ plan("tests" => (
 $acvars = new_ok("Warewulf::ACVars");
 can_ok($acvars, "new", "get", "vars");
 
-# Make sure we account for all the variables that exist currently.
-cmp_ok(scalar(@var_names), '==', scalar($acvars->vars()),
+# Make sure we account for all the variables that exist currently (we explicitly ignore GITVERSION).
+cmp_ok(scalar(@var_names), '==', scalar($acvars->vars())-1,
        "All Warewulf::ACVars variable names accounted for");
 # Make sure static and non-static calls both work (and match).
 @a = $acvars->vars();

--- a/common/t/10-acvars.t
+++ b/common/t/10-acvars.t
@@ -23,23 +23,24 @@ my @var_names = (
     "DATAROOTDIR",
     "DATADIR",
     "LIBEXECDIR",
-    "PERLMODDIR"
+    "PERLMODDIR",
+    "GITVERSION"
 );
 my $acvars;
 my (@a, @b);
 
 plan("tests" => (
-         + 2                                           # Object tests
-         + 2                                           # Variable count tests
-         + (scalar(@var_names) * (1 + (2 * (6 * 2))))  # Invocation/value tests
+         + 2                                             # Object tests
+         + 2                                             # Variable count tests
+         + scalar(@var_names) * (1 + (2 * (6 * 2))) - 1  # Invocation/value tests
      ));
 
 # Can we create a Warewulf::ACVars object?
 $acvars = new_ok("Warewulf::ACVars");
 can_ok($acvars, "new", "get", "vars");
 
-# Make sure we account for all the variables that exist currently (we explicitly ignore GITVERSION).
-cmp_ok(scalar(@var_names), '==', scalar($acvars->vars())-1,
+# Make sure we account for all the variables that exist currently.
+cmp_ok(scalar(@var_names), '==', scalar($acvars->vars()),
        "All Warewulf::ACVars variable names accounted for");
 # Make sure static and non-static calls both work (and match).
 @a = $acvars->vars();
@@ -72,7 +73,7 @@ foreach my $orig_var (@var_names) {
             my $val;
 
             $val = eval "$scheme";
-            ok(defined($val) && $val, "$var is returned ($test)");
+            ok($orig_var eq "GITVERSION" || (defined($val) && $val), "$var is returned ($test)");
             cmp_ok($val, 'eq', $actual, "$var values match ($test)");
         }
     }
@@ -84,7 +85,7 @@ foreach my $orig_var (@var_names) {
         cmp_ok(substr($0, -$len, $len), 'eq', $actual, "PROGNAME matches \$0");
     } elsif ($orig_var eq "VERSION") {
         like($actual, qr/^[\d\.]+$/, "VERSION is a valid version number");
-    } else {
+    } elsif ($orig_var ne "GITVERSION") {
         like($actual, qr/^\//, "$orig_var starts with '/'");
     }
 }


### PR DESCRIPTION
Right now the test suite fails due to the added GITVERSION to `wwconfig`. This is a simple fix to ignore it (it may be empty). By default all tests must pass to build deb package.