### PR TITLE
Use devtmpfs if available to populate /dev instead of mdev

### DIFF
--- a/provision/initramfs/capabilities/provision-vnfs/70-devtree
+++ b/provision/initramfs/capabilities/provision-vnfs/70-devtree
@@ -2,14 +2,16 @@
 #
 # Copyright (c) 2001-2003 Gregory M. Kurtzer
 #
-# Copyright (c) 2003-2011, The Regents of the University of California,
+# Copyright (c) 2003-2017, The Regents of the University of California,
 # through Lawrence Berkeley National Laboratory (subject to receipt of any
 # required approvals from the U.S. Dept. of Energy).  All rights reserved.
 #
 
-if [ ! -d $NEWROOT/dev ]; then
-    mkdir -m 0755 -p $NEWROOT/dev;
+if [ ! -d "${NEWROOT}/dev" ]; then
+    mkdir -m 0755 -p "${NEWROOT}/dev";
 fi
 
-cp -rap /dev/* $NEWROOT/dev/
+if ! mount -t devtmpfs devtmpfs "${NEWROOT}/dev" >/dev/null 2>&1; then
+    cp -rap /dev/* "${NEWROOT}/dev/"
+fi
 

--- a/provision/initramfs/init
+++ b/provision/initramfs/init
@@ -3,17 +3,18 @@
 #
 # Copyright (c) 2001-2003 Gregory M. Kurtzer
 #
-# Copyright (c) 2003-2013, The Regents of the University of California,
+# Copyright (c) 2003-2017, The Regents of the University of California,
 # through Lawrence Berkeley National Laboratory (subject to receipt of any
 # required approvals from the U.S. Dept. of Energy).  All rights reserved.
 #
 
 
-mkdir /proc 2>/dev/null
-mkdir /sys  2>/dev/null
-mkdir /tmp  2>/dev/null
-mkdir /var  2>/dev/null
-mkdir /usr  2>/dev/null
+mkdir -p /proc 
+mkdir -p /sys
+mkdir -p /dev
+mkdir -p /tmp
+mkdir -p /var
+mkdir -p /usr
 
 mount -t proc none /proc >/dev/null 2>&1
 mount -t sysfs none /sys >/dev/null 2>&1
@@ -41,9 +42,12 @@ if [ -n "$WWHOSTNAME" ]; then
     wwsuccess
 fi
 
-if [ -x "/sbin/mdev" ]; then
-   echo /sbin/mdev > /proc/sys/kernel/hotplug
-   /sbin/mdev -s
+# Try to mount devtmpfs first, if it fails use mdev to populate /dev
+if ! mount -t devtmpfs devtmpfs /dev >/dev/null 2>&1; then
+    if [ -x "/sbin/mdev" ]; then
+        echo /sbin/mdev > /proc/sys/kernel/hotplug
+        /sbin/mdev -s
+    fi
 fi
 
 if [ -f "/etc/wwmodprobe" ]; then


### PR DESCRIPTION
Warewulf's existing implementation uses mdev. Mdev uses the kernel's asynchronous hotplug interface to be executed to populate /dev.

The current approach can cause a race condition on partitioning local disk, the devices being created/updated and formatting (or whatever the next step to access that partition's device). Devtmpfs has been around in the kernel at least since 2.6.32, so it's available in CentOS/RHEL 6.