### PR TITLE
Approved use of GNU parted via scripting in the Warewulf project.

### DIFF
--- a/provision/3rd_party/GPL/README
+++ b/provision/3rd_party/GPL/README
@@ -18,3 +18,4 @@ Signed-off-by:
 Bradley M. Kuhn, Executive Director, Software Freedom Conservancy, Busybox
 H. Peter Anvin, Syslinux Project
 Theodore Ts'o, E2fsprogs
+David Cantrell, GNU parted


### PR DESCRIPTION
Per the discussion via email, the inclusion of GNU Parted with the
Warewulf project creates an aggregate work.  Warewulf invokes the parted
executable via scripts rather than linking with libparted directly.  Per
the terms of the GPL, this is allowed.  Therefore, I have no problems
with Warewulf using and including GNU parted provided they continue to
comply with all terms of the GPL for parted related patches and uses.

Signed-off-by: David Cantrell <david.l.cantrell@gmail.com>