### PR TITLE
Optionally Validate VNFS Checksum On Boot

### DIFF
--- a/common/share/wwsh.1
+++ b/common/share/wwsh.1
@@ -704,6 +704,11 @@ Define the bootstrap image that this node should use.
 Define the VNFS that this node should use.
 .RE
 .PP
+.B \-\-validate        
+.RS 4
+Enable checksum validation of VNFS on boot.
+.RE
+.PP
 .B \-\-master      
 .RS 4
 Specifically set the Warewulf master(s) for this node.

--- a/provision/cgi-bin/nodeconfig.pl
+++ b/provision/cgi-bin/nodeconfig.pl
@@ -15,6 +15,8 @@ use Warewulf::Node;
 use Warewulf::Logger;
 use Warewulf::Object;
 use Warewulf::ObjectSet;
+use Warewulf::Vnfs;
+use Warewulf::Provision;
 
 &set_log_level("WARNING");
 
@@ -96,6 +98,16 @@ if ($hwaddr =~ /^([a-zA-Z0-9:]+)$/) {
         }
 
 
+    }
+    my ($vnfsid) = $node->vnfsid();
+    if ($vnfsid) {
+        my $vnfs_obj = $db->get_objects("vnfs", "_id", $vnfsid)->get_object(0);
+        if ($vnfs_obj) {
+            my $vnfs_name = $vnfs_obj->name();
+            print "WWVNFS_NAME=\"$vnfs_name\"\nexport WWVNFS_NAME\n";
+            my $vnfs_checksum = $vnfs_obj->checksum();
+            print "WWVNFS_CHECKSUM=\"$vnfs_checksum\"\nexport WWVNFS_CHECKSUM\n";
+        }
     }
 }
 

--- a/provision/initramfs/capabilities/provision-vnfs/30-getvnfs
+++ b/provision/initramfs/capabilities/provision-vnfs/30-getvnfs
@@ -2,18 +2,28 @@
 #
 # Copyright (c) 2001-2003 Gregory M. Kurtzer
 #
-# Copyright (c) 2003-2011, The Regents of the University of California,
+# Copyright (c) 2003-2017, The Regents of the University of California,
 # through Lawrence Berkeley National Laboratory (subject to receipt of any
 # required approvals from the U.S. Dept. of Energy).  All rights reserved.
 #
 
+[ -f /etc/functions ] && . /etc/functions
+
 SET_X=1
 export SET_X
 
-cd $NEWROOT
+cd "${NEWROOT}"
 
-if ! wwgetvnfs; then
+# Status for parent
+wwrunning
+
+wwgetvnfs
+
+RC=$?
+
+msg_white " * getvnfs"  
+
+if [ ${RC} -ne 0 ]; then
     exit 255
 fi
-
 

--- a/provision/initramfs/capabilities/transport-http/wwgetvnfs
+++ b/provision/initramfs/capabilities/transport-http/wwgetvnfs
@@ -11,42 +11,80 @@ if [ -n "$SET_X" ]; then
     set -x
 fi
 
-. /warewulf/transports/http/functions
+[ -f /etc/functions ] && . /etc/functions
+[ -f /warewulf/transports/http/functions ] && . /warewulf/transports/http/functions
 
-TMPFILE=`mktemp`
+VALIDATE_VNFS="${WWVALIDATE_VNFS:-0}"
 
-cd ${NEWROOT:-/}
+cd "${NEWROOT:-/}"
 
 while true; do
-    for master in `echo $WWMASTER | sed -e 's/,/ /g'`; do
+    for master in $(echo "${WWMASTER}" | sed -e 's/,/ /g'); do
 
-        rm -f /tmp/vnfs-download 2>/dev/null
-        if ! mkfifo /tmp/vnfs-download 2>/dev/null; then
+        rm -f /tmp/vnfs-download /tmp/vnfs-checksum /tmp/vnfs-extract 2>/dev/null
+        if ! mkfifo /tmp/vnfs-download /tmp/vnfs-checksum /tmp/vnfs-extract 2>/dev/null; then
             echo "ERROR: Could not create the fifo!"
             exit 1
         fi
 
-        gunzip < /tmp/vnfs-download | bsdtar -pxf - &
-        #gunzip < /tmp/vnfs-download | tar -xf - &
+        if [ "${VALIDATE_VNFS}" -eq 1 ]; then
+            
+            tee /tmp/vnfs-extract < /tmp/vnfs-download > /tmp/vnfs-checksum &
+            TEE_PID=$!
+            
+            gunzip < /tmp/vnfs-extract | bsdtar -pxf - 2>/dev/null &
+            EXTRACT_PID=$!
+            
+            md5sum /tmp/vnfs-checksum > /tmp/wwgetvnfs_checksum &
+            MD5SUM_PID=$!
 
-        wget -q -O /tmp/vnfs-download http://$master/WW/vnfs?hwaddr=$WWINIT_HWADDR 2>&1
-        WGETEXIT=$?
+        else
 
-        wait
-        if [ -x "$NEWROOT/sbin/init" -o -h "$NEWROOT/sbin/init" ]; then
-            echo
+            gunzip < /tmp/vnfs-download | bsdtar -pxf - &
+            EXTRACT_PID=$!
+
+        fi
+
+        wwlogger "vnfs ${WWVNFS_NAME}, ${WWVNFSID}, ${WWVNFS_CHECKSUM:-undef}"
+        msg_gray "   * fetching ${WWVNFS_NAME} (ID:${WWVNFSID})"
+
+        {
+            wget -q -O /tmp/vnfs-download "http://$master/WW/vnfs?hwaddr=$WWINIT_HWADDR" 2>&1 && wwsuccess
+        } || wwfailure
+
+        if [ -n "${TEE_PID:-}" ]; then
+            wait "${TEE_PID}" || true
+        fi
+
+        if [ -n "${MD5SUM_PID:-}" ]; then
+            wait "${MD5SUM_PID}" || true
+        fi
+
+        msg_gray "   * extracting"
+        {
+            wait "${EXTRACT_PID}" && wwsuccess
+        } || wwfailure
+
+        msg_gray "   * checksum ${WWVNFS_CHECKSUM:-}"
+         "   * checksum ${WWVNFS_CHECKSUM:-}"
+        if [ "${VALIDATE_VNFS}" -eq 1 ]; then
+            CHECKSUM=$(cut -f1 -d " " /tmp/wwgetvnfs_checksum)
+            if [ "${CHECKSUM}" != "${WWVNFS_CHECKSUM:-}" ]; then
+                wwfailure
+                exit 2
+            fi
+            wwlogger "vnfs checksum ${WWVNFS_CHECKSUM} matches"
+            wwsuccess
+        else
+            wwskipped
+        fi
+
+        if [ -x "$NEWROOT/sbin/init" ] || [ -h "$NEWROOT/sbin/init" ]; then
             exit 0
-	fi
+        fi
 
-#        ( wget -O - "http://$master/WW/vnfs?hwaddr=$WWINIT_HWADDR" | gunzip | tar -xf - ) 2>&1
-#        if [ -f "$NEWROOT/sbin/init" ]; then
-#            echo
-#            exit 0
-#        fi
     done
-    echo -n "."
     throttled_sleep
 done
-echo
 
 exit 1

--- a/provision/initramfs/capabilities/transport-http/wwgetvnfs
+++ b/provision/initramfs/capabilities/transport-http/wwgetvnfs
@@ -48,22 +48,29 @@ while true; do
         wwlogger "vnfs ${WWVNFS_NAME}, ${WWVNFSID}, ${WWVNFS_CHECKSUM:-undef}"
         msg_gray "   * fetching ${WWVNFS_NAME} (ID:${WWVNFSID})"
 
-        {
-            wget -q -O /tmp/vnfs-download "http://$master/WW/vnfs?hwaddr=$WWINIT_HWADDR" 2>&1 && wwsuccess
-        } || wwfailure
+        wget -q -O /tmp/vnfs-download "http://$master/WW/vnfs?hwaddr=$WWINIT_HWADDR" >/dev/null 2>&1
+        WGETEXIT=$?
 
-        if [ -n "${TEE_PID:-}" ]; then
-            wait "${TEE_PID}" || true
+        if [ "${WGETEXIT}" -eq 0 ]; then
+            wwsuccess
+
+            if [ -n "${TEE_PID:-}" ]; then
+                wait "${TEE_PID}" || true
+            fi
+
+            if [ -n "${MD5SUM_PID:-}" ]; then
+                wait "${MD5SUM_PID}" || true
+            fi
+
+            msg_gray "   * extracting"
+            {
+                wait "${EXTRACT_PID}" && wwsuccess
+            } || wwfailure
+        else
+            wwretrying
+            kill "${EXTRACT_PID}" "${TEE_PID:-}" "${MD5SUM_PID:-}" 2>/dev/null || true
+            continue
         fi
-
-        if [ -n "${MD5SUM_PID:-}" ]; then
-            wait "${MD5SUM_PID}" || true
-        fi
-
-        msg_gray "   * extracting"
-        {
-            wait "${EXTRACT_PID}" && wwsuccess
-        } || wwfailure
 
         msg_gray "   * checksum ${WWVNFS_CHECKSUM:-}"
          "   * checksum ${WWVNFS_CHECKSUM:-}"

--- a/provision/initramfs/functions
+++ b/provision/initramfs/functions
@@ -125,6 +125,11 @@ wwfailure() {
     msg_red "ERROR\n"
 }
 
+wwretrying() {
+    echo -en "\\033[72G"
+    msg_gray "RETRYING\n"
+}
+
 _doreboot() {
     local SLEEP=$1
     touch /reboot

--- a/provision/lib/Warewulf/Module/Cli/Provision.pm
+++ b/provision/lib/Warewulf/Module/Cli/Provision.pm
@@ -84,6 +84,7 @@ help()
     $h .= "     -l, --lookup        How should we reference this node? (default is name)\n";
     $h .= "     -b, --bootstrap     Define the bootstrap image that this node should use\n";
     $h .= "     -V, --vnfs          Define the VNFS that this node should use\n";
+    $h .= "         --validate      Enable checksum validation of VNFS on boot\n";
     $h .= "         --master        Specifically set the Warewulf master(s) for this node\n";
 # TODO: Bootserver is not being used yet...
 #    $h .= "         --bootserver    If you have multiple DHCP/TFTP servers, which should be\n";
@@ -178,6 +179,7 @@ exec()
     my $opt_lookup = "name";
     my $opt_bootstrap;
     my $opt_vnfs;
+    my $opt_validate;
     my $opt_preshell;
     my $opt_postshell;
     my $opt_postreboot;
@@ -219,6 +221,7 @@ exec()
         'bootserver=s'  => \@opt_bootserver,
         'b|bootstrap=s' => \$opt_bootstrap,
         'V|vnfs=s'      => \$opt_vnfs,
+        'validate=s'    => \$opt_validate,
         'preshell=s'    => \$opt_preshell,
         'postshell=s'   => \$opt_postshell,
         'postreboot=s'  => \$opt_postreboot,
@@ -304,6 +307,31 @@ exec()
                 } else {
                     &eprint("No VNFS named: $opt_vnfs\n");
                 }
+            }
+        }
+
+        if (defined($opt_validate)) {
+            if (uc($opt_validate) eq "UNDEF" or
+                uc($opt_validate) eq "FALSE" or
+                uc($opt_validate) eq "NO" or
+                uc($opt_validate) eq "N" or
+                $opt_validate == 0
+            ) {
+                foreach my $obj ($objSet->get_list()) {
+                    my $name = $obj->name() || "UNDEF";
+                    $obj->validate_vnfs(0);
+                    &dprint("Disabling checksum validation for node name: $name\n");
+                    $persist_bool = 1;
+                }
+                push(@changes, sprintf("   UNDEF: %-20s\n", "VALIDATE_VNFS"));
+            } else {
+                foreach my $obj ($objSet->get_list()) {
+                    my $name = $obj->name() || "UNDEF";
+                    $obj->validate_vnfs(1);
+                    &dprint("Enabling checksum validation for node name: $name\n");
+                    $persist_bool = 1;
+                }
+                push(@changes, sprintf("     SET: %-20s = %s\n", "VALIDATE_VNFS", 1));
             }
         }
 

--- a/provision/lib/Warewulf/Provision.pm
+++ b/provision/lib/Warewulf/Provision.pm
@@ -404,6 +404,29 @@ postreboot()
 }
 
 
+=item validate_vnfs($bool)
+
+Set or return the validate_vnfs boolean
+
+=cut
+
+sub
+validate_vnfs()
+{
+    my ($self, $bool) = @_;
+
+    if (defined($bool)) {
+        if ($bool) {
+            $self->set("validate_vnfs", 1);
+        } else {
+            $self->del("validate_vnfs");
+        }
+    }
+
+    return $self->get("validate_vnfs");
+}
+
+
 =item selinux($value)
 
 Set or return SELinux support


### PR DESCRIPTION
Add functionality to validate VNFS checksum on boot.

- Add new --validate boolean CLI arg for VNFS checksum validation
- Use tee to duplicate fifos so both md5sum and gunzip can consume the vnfs stream from wget
- Adds new variable WWVALIDATE_VNFS in the initrd to enable/disable md5sum validation
- Adds more feedback to console and syslog on each step of wwgetvnfs. Will display checksum fetched from the master even if WWVALIDATE_VNFS isn't enabled.
- Add VNFS_NAME and VNFS_CHECKSUM to variables exported for nodes in nodeconfig.pl
- Cleanup quoting and syntax to make shellcheck linter happy in shell scripts.
