### PR TITLE
Multi-Arch Support for Node, Bootstrap, VNFS, and Bootloader

### DIFF
--- a/common/lib/Warewulf/Node.pm
+++ b/common/lib/Warewulf/Node.pm
@@ -10,6 +10,7 @@ package Warewulf::Node;
 use Warewulf::Object;
 use Warewulf::ObjectSet;
 use Warewulf::Logger;
+use POSIX qw(uname);
 
 our @ISA = ('Warewulf::Object');
 
@@ -304,6 +305,7 @@ canonicalize()
     my $netdevs = $self->get("netdevs");
     my $nodename = $self->get("nodename");
     my $name = $self->get("name");
+    my (undef, undef, undef, undef, $machine) = POSIX::uname();
     my $changed = 0;
 
     if ($netdevs) {
@@ -339,6 +341,11 @@ canonicalize()
     if ($name and ! $nodename) {
         &iprint("Updating name array ($name): ". join(",", split(/\./, $name)) ."\n");
         $self->name(split(/\./, $name));
+        $changed++;
+    }
+    if (! $self->arch()) {
+        &iprint("This node has no arch define, defaulting to current system's arch");
+        $self->arch($machine);
         $changed++;
     }
     return($changed);
@@ -694,6 +701,20 @@ enabled()
     my $ret = $self->prop("enabled", qr/^([0-1]|true|false|UNDEF)$/i, @_);
 
     return ((defined($ret)) ? ($ret) : (1));
+}
+
+=item arch($string)
+
+Set or return the architecture of the node.
+
+=cut
+
+sub
+arch()
+{
+    my $self = shift;
+
+    return $self->prop("arch", qr/^([a-zA-Z0-9_]+)$/, @_);
 }
 
 =back

--- a/provision/.gitignore
+++ b/provision/.gitignore
@@ -14,3 +14,6 @@ ACVars.pm
 *~
 
 etc/warewulf-httpd.conf
+3rd_party/pcbios
+3rd_party/i386-efi
+3rd_party/x86_64-efi

--- a/provision/3rd_party/Makefile.am
+++ b/provision/3rd_party/Makefile.am
@@ -4,6 +4,8 @@ SYSLINUXTARGETS = lpxelinux.0 pxelinux.0 ldlinux.c32 syslinux64.efi syslinux32.e
 
 MAINTAINERCLEANFILES = Makefile.in
 
+MACHINE:=$(shell uname -m)
+
 all: $(SYSLINUXTARGETS)
 
 SYSLINUX_VERSION = 6.04-pre1
@@ -41,14 +43,14 @@ syslinux32.efi: syslinuxprepare
 	cp _work/$(SYSLINUX_DIR)/efi32/efi/syslinux.efi syslinux32.efi
 
 install-data-local: $(SYSLINUXTARGETS)
-	mkdir -p $(DESTDIR)/$(datadir)/warewulf/
+	mkdir -p $(DESTDIR)/$(datadir)/warewulf/$(MACHINE)
 	@ for i in $(SYSLINUXTARGETS); do \
-		install -m 644 $$i $(DESTDIR)/$(datadir)/warewulf/ ; \
+		install -m 644 $$i $(DESTDIR)/$(datadir)/warewulf/$(MACHINE)/ ; \
 	done
 
 uninstall-local:
 	@ for i in $(SYSLINUXTARGETS); do \
-		rm -f $(DESTDIR)/$(datadir)/warewulf/$$i ; \
+		rm -f $(DESTDIR)/$(datadir)/warewulf/$(MACHINE)/$$i ; \
 	done
 	rm -f prepare
 

--- a/provision/3rd_party/Makefile.am
+++ b/provision/3rd_party/Makefile.am
@@ -1,6 +1,6 @@
 SUBDIRS = GPL BSD
 
-SYSLINUXTARGETS = lpxelinux.0 pxelinux.0 ldlinux.c32 syslinux64.efi syslinux32.efi ldlinux.e32 ldlinux.e64
+SYSLINUXTARGETS = pcbios/lpxelinux.0 pcbios/pxelinux.0 pcbios/ldlinux.c32 x86_64-efi/syslinux.efi x86_64-efi/ldlinux.e64 i386-efi/syslinux.efi i386-efi/ldlinux.e32
 
 MAINTAINERCLEANFILES = Makefile.in
 
@@ -21,38 +21,48 @@ syslinuxprepare:
 	fi
 	touch prepare
 
-lpxelinux.0: syslinuxprepare
-	cp _work/$(SYSLINUX_DIR)/bios/core/lpxelinux.0 .
+pcbios/lpxelinux.0: syslinuxprepare
+	mkdir -p pcbios
+	cp _work/$(SYSLINUX_DIR)/bios/core/lpxelinux.0 pcbios/lpxelinux.0
 
-ldlinux.c32: syslinuxprepare
-	cp _work/$(SYSLINUX_DIR)/bios/com32/elflink/ldlinux/ldlinux.c32 .
+pcbios/ldlinux.c32: syslinuxprepare
+	mkdir -p pcbios
+	cp _work/$(SYSLINUX_DIR)/bios/com32/elflink/ldlinux/ldlinux.c32 pcbios/ldlinux.c32
 
-ldlinux.e32: syslinuxprepare
-	cp _work/$(SYSLINUX_DIR)/efi32/com32/elflink/ldlinux/ldlinux.e32 .
+i386-efi/ldlinux.e32: syslinuxprepare
+	mkdir -p i386-efi
+	cp _work/$(SYSLINUX_DIR)/efi32/com32/elflink/ldlinux/ldlinux.e32 i386-efi/ldlinux.e32
 
-ldlinux.e64: syslinuxprepare
-	cp _work/$(SYSLINUX_DIR)/efi64/com32/elflink/ldlinux/ldlinux.e64 .
+x86_64-efi/ldlinux.e64: syslinuxprepare
+	mkdir -p x86_64-efi
+	cp _work/$(SYSLINUX_DIR)/efi64/com32/elflink/ldlinux/ldlinux.e64 x86_64-efi/ldlinux.e64
 
-pxelinux.0: syslinuxprepare
-	cp _work/$(SYSLINUX_DIR)/bios/core/pxelinux.0 .
+pcbios/pxelinux.0: syslinuxprepare
+	mkdir -p pcbios
+	cp _work/$(SYSLINUX_DIR)/bios/core/pxelinux.0 pcbios/pxelinux.0
 
-syslinux64.efi: syslinuxprepare
-	cp _work/$(SYSLINUX_DIR)/efi64/efi/syslinux.efi syslinux64.efi
+x86_64-efi/syslinux.efi: syslinuxprepare
+	mkdir -p x86_64-efi
+	cp _work/$(SYSLINUX_DIR)/efi64/efi/syslinux.efi x86_64-efi/syslinux.efi
 
-syslinux32.efi: syslinuxprepare
-	cp _work/$(SYSLINUX_DIR)/efi32/efi/syslinux.efi syslinux32.efi
+i386-efi/syslinux.efi: syslinuxprepare
+	mkdir -p i386-efi
+	cp _work/$(SYSLINUX_DIR)/efi32/efi/syslinux.efi i386-efi/syslinux.efi
 
 install-data-local: $(SYSLINUXTARGETS)
-	mkdir -p $(DESTDIR)/$(datadir)/warewulf/$(MACHINE)
-	@ for i in $(SYSLINUXTARGETS); do \
-		install -m 644 $$i $(DESTDIR)/$(datadir)/warewulf/$(MACHINE)/ ; \
+	@ for i in $(SYSLINUXTARGETS) ; do \
+		installdir=$$(dirname $(DESTDIR)/$(datadir)/warewulf/$$i) ; \
+		mkdir -p $$installdir ; \
+		install -m 644 $$i $$installdir/ ; \
 	done
 
 uninstall-local:
 	@ for i in $(SYSLINUXTARGETS); do \
-		rm -f $(DESTDIR)/$(datadir)/warewulf/$(MACHINE)/$$i ; \
+		installdir=$$(dirname $(DESTDIR)/$(datadir)/warewulf/$$i) ; \
+		rm -f $(DESTDIR)/$(datadir)/warewulf/$$i ; \
+    rmdir $$installdir 2>/dev/null || true ; \
 	done
 	rm -f prepare
 
 clean-local:
-	rm -rf _work prepare $(SYSLINUXTARGETS)
+	rm -rf _work prepare $(SYSLINUXTARGETS) i386-efi x86_64-efi pcbios

--- a/provision/etc/dhcpd-template.conf
+++ b/provision/etc/dhcpd-template.conf
@@ -10,21 +10,21 @@ option pxelinux.configfile code 209 = text;
 option pxelinux.pathprefix code 210 = text;
 option architecture-type   code 93  = unsigned integer 16;
 
+vendor-option-space pxelinux;
+option pxelinux.magic f1:00:74:7e;
+if exists dhcp-parameter-request-list {
+    # Always send the PXELINUX options (specified in hexadecimal)
+    option dhcp-parameter-request-list = concat(option dhcp-parameter-request-list,d0,d1,d2,d3);
+}
+
+option pxelinux.pathprefix "/warewulf/";
 
 # IB Clients
 if substring(hardware,0,1) = 20 {
-    site-option-space "pxelinux";
-    option pxelinux.magic f1:00:74:7e;
-    if exists dhcp-parameter-request-list {
-        # Always send the PXELINUX options (specified in hexadecimal)
-        option dhcp-parameter-request-list = concat(option dhcp-parameter-request-list,d0,d1,d2,d3);
-    }
-    
-    option pxelinux.pathprefix "tftp://%{IPADDR}/warewulf/";
-    
+
     # Make IB PXE devices look in the correct place for their pxelinux configuration file.
     # Ensure the configuration filename is properly zero padded.
-    option pxelinux.configfile = concat ( 
+    option pxelinux.configfile = concat (
         "pxelinux.cfg/20-",
         suffix (concat ("0", binary-to-ascii (16, 8, "",
           substring (option dhcp-client-identifier, 12, 1))),2), "-",
@@ -46,17 +46,17 @@ if substring(hardware,0,1) = 20 {
     filename "tftp://%{IPADDR}/warewulf/loader/pcbios/pxelinux.0";
 # Ethernet Clients
 } else {
-    if option architecture-type = 11 {
+    if option architecture-type = 00:0B {
         filename "/warewulf/loader/arm64-efi/placeholder.efi";
-    } elsif option architecture-type = 10 {
+    } elsif option architecture-type = 00:0A {
         filename "/warewulf/loader/arm32-efi/placeholder.efi";
-    } elsif option architecture-type = 9 {
+    } elsif option architecture-type = 00:09 {
         filename "/warewulf/loader/x86_64-efi/syslinux.efi";
-    } elsif option architecture-type = 7 {
+    } elsif option architecture-type = 00:07 {
         filename "/warewulf/loader/x86_64-efi/syslinux.efi";
-    } elsif option architecture-type = 6 {
+    } elsif option architecture-type = 00:06 {
         filename "/warewulf/loader/i386-efi/syslinux.efi";
-    } elsif option architecture-type = 0 {
+    } elsif option architecture-type = 00:00 {
         filename "/warewulf/loader/pcbios/lpxelinux.0";
     }
 }

--- a/provision/etc/dhcpd-template.conf
+++ b/provision/etc/dhcpd-template.conf
@@ -43,17 +43,21 @@ if substring(hardware,0,1) = 20 {
         suffix (concat ("0", binary-to-ascii (16, 8, "",
           substring (option dhcp-client-identifier, 19, 1))),2));
 
-    filename "tftp://%{IPADDR}/warewulf/pxelinux.0";
+    filename "tftp://%{IPADDR}/warewulf/loader/pcbios/pxelinux.0";
 # Ethernet Clients
 } else {
-    if option architecture-type = 00:09 {
-        filename "/warewulf/syslinux64.efi";
-    } elsif option architecture-type = 00:07 {
-        filename "/warewulf/syslinux64.efi";
-    } elsif option architecture-type = 00:06 {
-        filename "/warewulf/syslinux32.efi";
-    } else {
-        filename "/warewulf/lpxelinux.0";
+    if option architecture-type = 11 {
+        filename "/warewulf/loader/arm64-efi/placeholder.efi";
+    } elsif option architecture-type = 10 {
+        filename "/warewulf/loader/arm32-efi/placeholder.efi";
+    } elsif option architecture-type = 9 {
+        filename "/warewulf/loader/x86_64-efi/syslinux.efi";
+    } elsif option architecture-type = 7 {
+        filename "/warewulf/loader/x86_64-efi/syslinux.efi";
+    } elsif option architecture-type = 6 {
+        filename "/warewulf/loader/i386-efi/syslinux.efi";
+    } elsif option architecture-type = 0 {
+        filename "/warewulf/loader/pcbios/lpxelinux.0";
     }
 }
 

--- a/provision/initramfs/Makefile.am
+++ b/provision/initramfs/Makefile.am
@@ -4,6 +4,8 @@ all: initramfs.cpio
 
 top_srcdir = @top_srcdir@
 
+MACHINE:=$(shell uname -m)
+
 BUSYBOX_VERSION = 1.26.2
 BUSYBOX_SOURCE = $(top_srcdir)/3rd_party/GPL/busybox-$(BUSYBOX_VERSION).tar.bz2
 BUSYBOX_DIR = busybox-$(BUSYBOX_VERSION)
@@ -131,10 +133,11 @@ initramfs.cpio: rootfs
 
 install-data-local: initramfs.cpio
 	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/
-	install -m 644 initramfs.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/base
+	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)
+	install -m 644 initramfs.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/base
 
 uninstall-local:
-	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/base
+	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/base
 
 clean-local:
 	rm -rf _work rootfs initramfs.cpio

--- a/provision/initramfs/capabilities/provision-adhoc/Makefile.am
+++ b/provision/initramfs/capabilities/provision-adhoc/Makefile.am
@@ -2,6 +2,8 @@ METHODSCRIPTS = 05-adhoc-pre 90-adhoc-post
 
 MAINTAINERCLEANFILES = Makefile.in
 
+MACHINE:=$(shell uname -m)
+
 rootfs:
 	rm -rf rootfs
 	mkdir -p rootfs/warewulf/provision/
@@ -14,11 +16,11 @@ capability.cpio: rootfs
 	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
 
 install-data-local: capability.cpio
-	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities
-	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/provision-adhoc
+	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities
+	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/provision-adhoc
 
 uninstall-local:
-	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/provision-adhoc
+	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/provision-adhoc
 
 clean-local:
 	rm -rf rootfs capability.cpio

--- a/provision/initramfs/capabilities/provision-files/Makefile.am
+++ b/provision/initramfs/capabilities/provision-files/Makefile.am
@@ -2,6 +2,8 @@ METHODSCRIPTS = 80-files
 
 MAINTAINERCLEANFILES = Makefile.in
 
+MACHINE:=$(shell uname -m)
+
 rootfs:
 	rm -rf rootfs
 	mkdir -p rootfs/warewulf/provision/
@@ -14,11 +16,11 @@ capability.cpio: rootfs
 	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
 
 install-data-local: capability.cpio
-	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities
-	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/provision-files
+	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities
+	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/provision-files
 
 uninstall-local:
-	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/provision-files
+	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/provision-files
 
 clean-local:
 	rm -rf rootfs capability.cpio

--- a/provision/initramfs/capabilities/provision-selinux/Makefile.am
+++ b/provision/initramfs/capabilities/provision-selinux/Makefile.am
@@ -2,6 +2,8 @@ METHODSCRIPTS = 95-selinux
 
 MAINTAINERCLEANFILES = Makefile.in
 
+MACHINE:=$(shell uname -m)
+
 rootfs:
 	rm -rf rootfs
 	mkdir -p rootfs/warewulf/provision/
@@ -14,11 +16,11 @@ capability.cpio: rootfs
 	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
 
 install-data-local: capability.cpio
-	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities
-	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/provision-selinux
+	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities
+	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/provision-selinux
 
 uninstall-local:
-	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/provision-selinux
+	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/provision-selinux
 
 clean-local:
 	rm -rf rootfs capability.cpio

--- a/provision/initramfs/capabilities/provision-unionfs/Makefile.am
+++ b/provision/initramfs/capabilities/provision-unionfs/Makefile.am
@@ -1,5 +1,7 @@
 MAINTAINERCLEANFILES = Makefile.in
 
+MACHINE:=$(shell uname -m)
+
 all: unionfs
 
 top_srcdir = @top_srcdir@
@@ -37,11 +39,11 @@ capability.cpio: rootfs
 	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
 
 install-data-local: capability.cpio
-	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities
-	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/provision-unionfs
+	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities
+	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/provision-unionfs
 
 uninstall-local:
-	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/provision-unionfs
+	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/provision-unionfs
 
 clean-local:
 	rm -rf _work rootfs unionfs capability.cpio

--- a/provision/initramfs/capabilities/provision-vnfs/Makefile.am
+++ b/provision/initramfs/capabilities/provision-vnfs/Makefile.am
@@ -2,6 +2,8 @@ METHODSCRIPTS = 30-getvnfs 50-config 60-runtimesupport 70-devtree 70-kernelmodul
 
 MAINTAINERCLEANFILES = Makefile.in
 
+MACHINE:=$(shell uname -m)
+
 rootfs:
 	rm -rf rootfs
 	mkdir -p rootfs/warewulf/provision/
@@ -14,11 +16,11 @@ capability.cpio: rootfs
 	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
 
 install-data-local: capability.cpio
-	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities
-	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/provision-vnfs
+	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities
+	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/provision-vnfs
 
 uninstall-local:
-	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/provision-vnfs
+	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/provision-vnfs
 
 clean-local:
 	rm -rf rootfs capability.cpio

--- a/provision/initramfs/capabilities/setup-filesystems/Makefile.am
+++ b/provision/initramfs/capabilities/setup-filesystems/Makefile.am
@@ -2,6 +2,8 @@ METHODSCRIPTS = 20-filesystems 80-mkbootable 95-umount 99-postreboot
 
 MAINTAINERCLEANFILES = Makefile.in
 
+MACHINE:=$(shell uname -m)
+
 rootfs:
 	rm -rf rootfs
 	mkdir -p rootfs/warewulf/provision/
@@ -14,11 +16,11 @@ capability.cpio: rootfs
 	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
 
 install-data-local: capability.cpio
-	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities
-	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/setup-filesystems
+	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities
+	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/setup-filesystems
 
 uninstall-local:
-	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/setup-filesystems
+	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/setup-filesystems
 
 clean-local:
 	rm -rf rootfs capability.cpio

--- a/provision/initramfs/capabilities/transport-http/Makefile.am
+++ b/provision/initramfs/capabilities/transport-http/Makefile.am
@@ -2,6 +2,8 @@ METHODSCRIPTS = wwgetscript wwgetnodeconfig wwgetvnfs register functions wwgetfi
 
 MAINTAINERCLEANFILES = Makefile.in
 
+MACHINE:=$(shell uname -m)
+
 TRANSPORT_NAME = http
 
 
@@ -17,11 +19,11 @@ capability.cpio: rootfs
 	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
 
 install-data-local: capability.cpio
-	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities
-	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/transport-http
+	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities
+	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/transport-http
 
 uninstall-local:
-	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/transport-http
+	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/transport-http
 
 clean-local:
 	rm -rf rootfs capability.cpio

--- a/provision/lib/Warewulf/Bootstrap.pm
+++ b/provision/lib/Warewulf/Bootstrap.pm
@@ -335,7 +335,7 @@ build_local_bootstrap()
             &nprint("Integrating the Warewulf bootstrap: $bootstrap_name\n");
 
             if (! -d "$initramfsdir") {
-                &wprint("Could not locate the initramfs directory for bootstrap's architecture at $initramfsdir, SKIPPING...\n");
+                &wprint("Could not locate the initramfs directory for bootstrap's architecture at $initramfsdir, cannot integrate this bootstrap on this host...\n");
                 return();
             }
 

--- a/provision/lib/Warewulf/Bootstrap.pm
+++ b/provision/lib/Warewulf/Bootstrap.pm
@@ -18,6 +18,7 @@ use Warewulf::Provision::Tftp;
 use File::Basename;
 use File::Path;
 use Digest::MD5 qw(md5_hex);
+use POSIX qw(uname);
 
 
 our @ISA = ('Warewulf::Object');
@@ -109,6 +110,20 @@ size()
 }
 
 
+=item arch($string)
+
+Set or return the architecture of the raw file stored within the data store.
+
+=cut
+
+sub
+arch()
+{
+    my $self = shift;
+
+    return $self->prop("arch", qr/^([a-zA-Z0-9_]+)$/, @_);
+}
+
 =item bootstrap_import($file)
 
 Import a bootstrap image at the defined path into the data store directly.
@@ -123,12 +138,18 @@ sub
 bootstrap_import()
 {
     my ($self, $path) = @_;
+    my (undef, undef, undef, undef, $machine) = POSIX::uname();
 
     my $id = $self->id();
 
     if (! $id) {
         &eprint("This object has no ID!\n");
         return();
+    }
+
+    if (! $self->arch()) {
+        &dprint("This object has no arch, defaulting to current system's arch");
+        $self->arch($machine);
     }
 
     if ($path) {

--- a/provision/lib/Warewulf/Bootstrap.pm
+++ b/provision/lib/Warewulf/Bootstrap.pm
@@ -392,10 +392,24 @@ build_local_bootstrap()
 }
 
 
+=item canonicalize()
+Check and update the object if necessary. Returns the number of changes made.
+=cut
 
+sub
+canonicalize()
+{
+    my ($self) = @_;
+    my (undef, undef, undef, undef, $arch) = POSIX::uname();
+    my $changed = 0;
 
-
-
+    if (! $self->arch()) {
+        &iprint("This bootstrap has no arch define, defaulting to current system's arch");
+        $self->arch($arch);
+        $changed++;
+    }
+    return($changed);
+}
 
 
 =back

--- a/provision/lib/Warewulf/Bootstrap.pm
+++ b/provision/lib/Warewulf/Bootstrap.pm
@@ -334,6 +334,11 @@ build_local_bootstrap()
 
             &nprint("Integrating the Warewulf bootstrap: $bootstrap_name\n");
 
+            if (! -d "$initramfsdir") {
+                &wprint("Could not locate the initramfs directory for bootstrap's architecture at $initramfsdir, SKIPPING...\n");
+                return();
+            }
+
             if (-f "$bootstrapdir/cookie") {
                 open(COOKIE, "$bootstrapdir/cookie");
                 chomp (my $cookie = <COOKIE>);
@@ -369,6 +374,7 @@ build_local_bootstrap()
                 system("cd $tmpdir/initramfs; cpio -i -u --quiet < $initramfsdir/base");
             } else {
                 &eprint("Could not locate the Warewulf bootstrap 'base' capability\n");
+                return();
             }
 
 

--- a/provision/lib/Warewulf/Bootstrap.pm
+++ b/provision/lib/Warewulf/Bootstrap.pm
@@ -238,13 +238,14 @@ delete_local_bootstrap()
     if ($self) {
         my $bootstrap_name = $self->get("name") || "UNDEF";
         my $bootstrap_id = $self->get("_id");
+        my $arch = $self->get("arch");
 
         &dprint("Going to delete bootstrap: $bootstrap_name\n");
 
-        if ($bootstrap_id =~ /^([0-9]+)$/) {
+        if ($bootstrap_id =~ /^([0-9]+)$/ && $arch) {
             my $id = $1;
             my $tftpboot = Warewulf::Provision::Tftp->new()->tftpdir();
-            my $bootstrapdir = "$tftpboot/warewulf/bootstrap/$bootstrap_id/";
+            my $bootstrapdir = "$tftpboot/warewulf/bootstrap/$arch/$bootstrap_id/";
 
             &nprint("Deleting local bootable bootstrap files: $bootstrap_name\n");
 
@@ -301,6 +302,11 @@ build_local_bootstrap()
     if ($self) {
         my $bootstrap_name = $self->name();
         my $bootstrap_id = $self->id();
+        my $arch = $self->arch();
+        if (! $arch) {
+            (undef, undef, undef, undef, $arch) = POSIX::uname();
+            &dprint("No architecture specified for bootstrap $bootstrap_name, default to local system");
+        }
 
         if (!$bootstrap_name) {
             &dprint("Skipping build_bootstrap() as the name is undefined\n");
@@ -319,11 +325,11 @@ build_local_bootstrap()
             my $id = $1;
             my $ds = Warewulf::DataStore->new();
             my $tftpboot = Warewulf::Provision::Tftp->new()->tftpdir();
-            my $initramfsdir = &Warewulf::ACVars::get("statedir") . "/warewulf/initramfs/";
+            my $initramfsdir = &Warewulf::ACVars::get("statedir") . "/warewulf/initramfs/$arch";
             my $randstring = &rand_string("12");
             my $tmpdir = "/var/tmp/wwinitrd.$randstring";
             my $binstore = $ds->binstore($bootstrap_id);
-            my $bootstrapdir = "$tftpboot/warewulf/bootstrap/$bootstrap_id/";
+            my $bootstrapdir = "$tftpboot/warewulf/bootstrap/$arch/$bootstrap_id/";
             my $initramfs = "$initramfsdir/initfs";
 
             &nprint("Integrating the Warewulf bootstrap: $bootstrap_name\n");

--- a/provision/lib/Warewulf/Module/Cli/Provision.pm
+++ b/provision/lib/Warewulf/Module/Cli/Provision.pm
@@ -269,9 +269,18 @@ exec()
                 push(@changes, sprintf("   UNDEF: %-20s\n", "BOOTSTRAP"));
             } else {
                 my $bootstrapObj = $db->get_objects("bootstrap", "name", $opt_bootstrap)->get_object(0);
+                
                 if ($bootstrapObj and my $bootstrapid = $bootstrapObj->get("_id")) {
+                    
+                    my $bootstrapArch = $bootstrapObj->arch();
+
                     foreach my $obj ($objSet->get_list()) {
                         my $name = $obj->name() || "UNDEF";
+                        my $arch = $obj->arch();
+                        if ($arch && $bootstrapArch && $arch ne $bootstrapArch) {
+                          &eprint("Bootstrap ARCH ($bootstrapArch) does not match node ARCH ($arch), skipping!\n");
+                          next;
+                        }
                         $obj->bootstrapid($bootstrapid);
                         &dprint("Setting bootstrapid for node name: $name\n");
                         $persist_bool = 1;
@@ -295,8 +304,14 @@ exec()
             } else {
                 my $vnfsObj = $db->get_objects("vnfs", "name", $opt_vnfs)->get_object(0);
                 if ($vnfsObj and my $vnfsid = $vnfsObj->get("_id")) {
+                    my $vnfsArch = $vnfsObj->arch();
                     foreach my $obj ($objSet->get_list()) {
                         my $name = $obj->name() || "UNDEF";
+                        my $arch = $obj->arch();
+                        if ($arch && $vnfsArch && $arch ne $vnfsArch) {
+                          &eprint("Vnfs ARCH ($vnfsArch) does not match node ARCH ($arch), skipping!\n");
+                          next;
+                        }
                         $obj->vnfsid($vnfsid);
                         &dprint("Setting vnfsid for node name: $name\n");
                         $persist_bool = 1;

--- a/provision/lib/Warewulf/Provision/Pxelinux.pm
+++ b/provision/lib/Warewulf/Provision/Pxelinux.pm
@@ -17,6 +17,7 @@ use Warewulf::Object;
 use Warewulf::Network;
 use Warewulf::DataStore;
 use Warewulf::Provision::Tftp;
+use File::Basename;
 use File::Path;
 use POSIX qw(uname);
 
@@ -83,16 +84,16 @@ setup()
     my $self = shift;
     my $datadir = &Warewulf::ACVars::get("datadir");
     my $tftpdir = Warewulf::Provision::Tftp->new()->tftpdir();
-    my @tftpfiles = ("pxelinux.0", "lpxelinux.0", "ldlinux.c32", "ldlinux.e32", "ldlinux.e64", "syslinux64.efi", "syslinux32.efi");
-    my (undef, undef, undef, undef, $arch) = POSIX::uname();
+    my @tftpfiles = ("pcbios/pxelinux.0", "pcbios/lpxelinux.0", "pcbios/ldlinux.c32", "i386-efi/ldlinux.e32", "x86_64-efi/ldlinux.e64", "x86-64-efi/syslinux.efi", "i386-efi/syslinux.efi");
 
     if ($tftpdir) {
         foreach my $f (@tftpfiles) {
-            if (! -f "$tftpdir/warewulf/loader/$arch/$f") {
-                if (-f "$datadir/warewulf/$arch/$f") {
+            if (! -f "$tftpdir/warewulf/loader/$f") {
+                if (-f "$datadir/warewulf/$f") {
                     &iprint("Copying $f to the tftp root\n");
-                    mkpath("$tftpdir/warewulf/loader/$arch");
-                    system("cp $datadir/warewulf/$arch/$f $tftpdir/warewulf/loader/$arch/$f");
+                    my $dirname = dirname("$tftpdir/warewulf/loader/$f");
+                    mkpath($dirname);
+                    system("cp $datadir/warewulf/$f $tftpdir/warewulf/loader/$f");
                 } else {
                     &eprint("Could not locate Warewulf's internal $f! Things might be broken!\n");
                 }

--- a/provision/lib/Warewulf/Vnfs.pm
+++ b/provision/lib/Warewulf/Vnfs.pm
@@ -15,6 +15,7 @@ use Warewulf::Util;
 use File::Basename;
 use File::Path;
 use Digest::MD5 qw(md5_hex);
+use POSIX qw(uname);
 
 
 
@@ -76,6 +77,19 @@ name()
     return $self->prop("name", qr/^([a-zA-Z0-9_\.\-]+)$/, @_);
 }
 
+=item arch($string)
+
+Set or return the architecture of the raw file stored within the data store.
+
+=cut
+
+sub
+arch()
+{
+    my $self = shift;
+
+    return $self->prop("arch", qr/^([a-zA-Z0-9_]+)$/, @_);
+}
 
 =item checksum($string)
 
@@ -139,12 +153,18 @@ sub
 vnfs_import()
 {
     my ($self, $path) = @_;
+    my (undef, undef, undef, undef, $machine) = POSIX::uname();
 
     my $id = $self->id();
 
     if (! $id) {
         &eprint("This object has no ID!\n");
         return();
+    }
+
+    if (! $self->arch()) {
+        &dprint("This object has no arch, defaulting to current system's arch");
+        $self->arch($machine);
     }
 
     if ($path) {

--- a/provision/lib/Warewulf/Vnfs.pm
+++ b/provision/lib/Warewulf/Vnfs.pm
@@ -240,6 +240,25 @@ vnfs_export()
 }
 
 
+=item canonicalize()
+Check and update the object if necessary. Returns the number of changes made.
+=cut
+
+sub
+canonicalize()
+{
+    my ($self) = @_;
+    my (undef, undef, undef, undef, $arch) = POSIX::uname();
+    my $changed = 0;
+
+    if (! $self->arch()) {
+        &iprint("This VNFS has no arch define, defaulting to current system's arch");
+        $self->arch($arch);
+        $changed++;
+    }
+    return($changed);
+}
+
 
 =back
 

--- a/provision/warewulf-provision.spec.in
+++ b/provision/warewulf-provision.spec.in
@@ -128,13 +128,13 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) %{_sysconfdir}/httpd/conf.d/warewulf-httpd.conf
 %{_bindir}/*
 %attr(0750, root, apache) %{_libexecdir}/warewulf/cgi-bin/
-%{_datadir}/warewulf/ldlinux.c32
-%{_datadir}/warewulf/ldlinux.e32
-%{_datadir}/warewulf/ldlinux.e64
-%{_datadir}/warewulf/lpxelinux.0
-%{_datadir}/warewulf/pxelinux.0
-%{_datadir}/warewulf/syslinux32.efi
-%{_datadir}/warewulf/syslinux64.efi
+%{_datadir}/warewulf/%{_arch}/ldlinux.c32
+%{_datadir}/warewulf/%{_arch}/ldlinux.e32
+%{_datadir}/warewulf/%{_arch}/ldlinux.e64
+%{_datadir}/warewulf/%{_arch}/lpxelinux.0
+%{_datadir}/warewulf/%{_arch}/pxelinux.0
+%{_datadir}/warewulf/%{_arch}/syslinux32.efi
+%{_datadir}/warewulf/%{_arch}/syslinux64.efi
 %{perl_vendorlib}/Warewulf/Event/Bootstrap.pm
 %{perl_vendorlib}/Warewulf/Event/Dhcp.pm
 %{perl_vendorlib}/Warewulf/Event/Pxelinux.pm

--- a/provision/warewulf-provision.spec.in
+++ b/provision/warewulf-provision.spec.in
@@ -128,13 +128,13 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) %{_sysconfdir}/httpd/conf.d/warewulf-httpd.conf
 %{_bindir}/*
 %attr(0750, root, apache) %{_libexecdir}/warewulf/cgi-bin/
-%{_datadir}/warewulf/%{_arch}/ldlinux.c32
-%{_datadir}/warewulf/%{_arch}/ldlinux.e32
-%{_datadir}/warewulf/%{_arch}/ldlinux.e64
-%{_datadir}/warewulf/%{_arch}/lpxelinux.0
-%{_datadir}/warewulf/%{_arch}/pxelinux.0
-%{_datadir}/warewulf/%{_arch}/syslinux32.efi
-%{_datadir}/warewulf/%{_arch}/syslinux64.efi
+%{_datadir}/warewulf/pcbios/pxelinux.0
+%{_datadir}/warewulf/pcbios/lpxelinux.0
+%{_datadir}/warewulf/pcbios/ldlinux.c32
+%{_datadir}/warewulf/i386-efi/syslinux.efi
+%{_datadir}/warewulf/i386-efi/ldlinux.e32
+%{_datadir}/warewulf/x86_64-efi/syslinux.efi
+%{_datadir}/warewulf/x86_64-efi/ldlinux.e64
 %{perl_vendorlib}/Warewulf/Event/Bootstrap.pm
 %{perl_vendorlib}/Warewulf/Event/Dhcp.pm
 %{perl_vendorlib}/Warewulf/Event/Pxelinux.pm


### PR DESCRIPTION
First step in supporting multiple architectures. Adding the ARCH attribute to nodes, VNFS, and bootstraps. This will be used for:

1. Validation that the VNFS and bootstrap have a matching ARCH when assigned to a node.
2. Specifying the correct boot loader paths (i.e. path to architecture specific binaries for boot loader) 

For all three object types, default to the local system's architecture so we don't mess with existing workflows. wwvnfs and wwbootstrap still need to be extended for this change, but that will be in a separate PR.