### PR TITLE
Install bootloader and initramfs components into a new architecture specific subdirectory

### DIFF
--- a/provision/3rd_party/Makefile.am
+++ b/provision/3rd_party/Makefile.am
@@ -4,6 +4,8 @@ SYSLINUXTARGETS = lpxelinux.0 pxelinux.0 ldlinux.c32 syslinux64.efi syslinux32.e
 
 MAINTAINERCLEANFILES = Makefile.in
 
+MACHINE:=$(shell uname -m)
+
 all: $(SYSLINUXTARGETS)
 
 SYSLINUX_VERSION = 6.04-pre1
@@ -41,14 +43,14 @@ syslinux32.efi: syslinuxprepare
 	cp _work/$(SYSLINUX_DIR)/efi32/efi/syslinux.efi syslinux32.efi
 
 install-data-local: $(SYSLINUXTARGETS)
-	mkdir -p $(DESTDIR)/$(datadir)/warewulf/
+	mkdir -p $(DESTDIR)/$(datadir)/warewulf/$(MACHINE)
 	@ for i in $(SYSLINUXTARGETS); do \
-		install -m 644 $$i $(DESTDIR)/$(datadir)/warewulf/ ; \
+		install -m 644 $$i $(DESTDIR)/$(datadir)/warewulf/$(MACHINE)/ ; \
 	done
 
 uninstall-local:
 	@ for i in $(SYSLINUXTARGETS); do \
-		rm -f $(DESTDIR)/$(datadir)/warewulf/$$i ; \
+		rm -f $(DESTDIR)/$(datadir)/warewulf/$(MACHINE)/$$i ; \
 	done
 	rm -f prepare
 

--- a/provision/initramfs/Makefile.am
+++ b/provision/initramfs/Makefile.am
@@ -4,6 +4,8 @@ all: initramfs.cpio
 
 top_srcdir = @top_srcdir@
 
+MACHINE:=$(shell uname -m)
+
 BUSYBOX_VERSION = 1.26.2
 BUSYBOX_SOURCE = $(top_srcdir)/3rd_party/GPL/busybox-$(BUSYBOX_VERSION).tar.bz2
 BUSYBOX_DIR = busybox-$(BUSYBOX_VERSION)
@@ -131,10 +133,11 @@ initramfs.cpio: rootfs
 
 install-data-local: initramfs.cpio
 	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/
-	install -m 644 initramfs.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/base
+	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)
+	install -m 644 initramfs.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/base
 
 uninstall-local:
-	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/base
+	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/base
 
 clean-local:
 	rm -rf _work rootfs initramfs.cpio

--- a/provision/initramfs/capabilities/provision-adhoc/Makefile.am
+++ b/provision/initramfs/capabilities/provision-adhoc/Makefile.am
@@ -2,6 +2,8 @@ METHODSCRIPTS = 05-adhoc-pre 90-adhoc-post
 
 MAINTAINERCLEANFILES = Makefile.in
 
+MACHINE:=$(shell uname -m)
+
 rootfs:
 	rm -rf rootfs
 	mkdir -p rootfs/warewulf/provision/
@@ -14,11 +16,11 @@ capability.cpio: rootfs
 	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
 
 install-data-local: capability.cpio
-	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities
-	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/provision-adhoc
+	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities
+	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/provision-adhoc
 
 uninstall-local:
-	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/provision-adhoc
+	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/provision-adhoc
 
 clean-local:
 	rm -rf rootfs capability.cpio

--- a/provision/initramfs/capabilities/provision-files/Makefile.am
+++ b/provision/initramfs/capabilities/provision-files/Makefile.am
@@ -2,6 +2,8 @@ METHODSCRIPTS = 80-files
 
 MAINTAINERCLEANFILES = Makefile.in
 
+MACHINE:=$(shell uname -m)
+
 rootfs:
 	rm -rf rootfs
 	mkdir -p rootfs/warewulf/provision/
@@ -14,11 +16,11 @@ capability.cpio: rootfs
 	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
 
 install-data-local: capability.cpio
-	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities
-	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/provision-files
+	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities
+	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/provision-files
 
 uninstall-local:
-	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/provision-files
+	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/provision-files
 
 clean-local:
 	rm -rf rootfs capability.cpio

--- a/provision/initramfs/capabilities/provision-selinux/Makefile.am
+++ b/provision/initramfs/capabilities/provision-selinux/Makefile.am
@@ -2,6 +2,8 @@ METHODSCRIPTS = 95-selinux
 
 MAINTAINERCLEANFILES = Makefile.in
 
+MACHINE:=$(shell uname -m)
+
 rootfs:
 	rm -rf rootfs
 	mkdir -p rootfs/warewulf/provision/
@@ -14,11 +16,11 @@ capability.cpio: rootfs
 	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
 
 install-data-local: capability.cpio
-	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities
-	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/provision-selinux
+	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities
+	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/provision-selinux
 
 uninstall-local:
-	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/provision-selinux
+	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/provision-selinux
 
 clean-local:
 	rm -rf rootfs capability.cpio

--- a/provision/initramfs/capabilities/provision-unionfs/Makefile.am
+++ b/provision/initramfs/capabilities/provision-unionfs/Makefile.am
@@ -1,5 +1,7 @@
 MAINTAINERCLEANFILES = Makefile.in
 
+MACHINE:=$(shell uname -m)
+
 all: unionfs
 
 top_srcdir = @top_srcdir@
@@ -37,11 +39,11 @@ capability.cpio: rootfs
 	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
 
 install-data-local: capability.cpio
-	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities
-	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/provision-unionfs
+	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities
+	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/provision-unionfs
 
 uninstall-local:
-	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/provision-unionfs
+	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/provision-unionfs
 
 clean-local:
 	rm -rf _work rootfs unionfs capability.cpio

--- a/provision/initramfs/capabilities/provision-vnfs/Makefile.am
+++ b/provision/initramfs/capabilities/provision-vnfs/Makefile.am
@@ -2,6 +2,8 @@ METHODSCRIPTS = 30-getvnfs 50-config 60-runtimesupport 70-devtree 70-kernelmodul
 
 MAINTAINERCLEANFILES = Makefile.in
 
+MACHINE:=$(shell uname -m)
+
 rootfs:
 	rm -rf rootfs
 	mkdir -p rootfs/warewulf/provision/
@@ -14,11 +16,11 @@ capability.cpio: rootfs
 	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
 
 install-data-local: capability.cpio
-	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities
-	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/provision-vnfs
+	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities
+	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/provision-vnfs
 
 uninstall-local:
-	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/provision-vnfs
+	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/provision-vnfs
 
 clean-local:
 	rm -rf rootfs capability.cpio

--- a/provision/initramfs/capabilities/setup-filesystems/Makefile.am
+++ b/provision/initramfs/capabilities/setup-filesystems/Makefile.am
@@ -2,6 +2,8 @@ METHODSCRIPTS = 20-filesystems 80-mkbootable 95-umount 99-postreboot
 
 MAINTAINERCLEANFILES = Makefile.in
 
+MACHINE:=$(shell uname -m)
+
 rootfs:
 	rm -rf rootfs
 	mkdir -p rootfs/warewulf/provision/
@@ -14,11 +16,11 @@ capability.cpio: rootfs
 	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
 
 install-data-local: capability.cpio
-	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities
-	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/setup-filesystems
+	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities
+	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/setup-filesystems
 
 uninstall-local:
-	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/setup-filesystems
+	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/setup-filesystems
 
 clean-local:
 	rm -rf rootfs capability.cpio

--- a/provision/initramfs/capabilities/transport-http/Makefile.am
+++ b/provision/initramfs/capabilities/transport-http/Makefile.am
@@ -2,6 +2,8 @@ METHODSCRIPTS = wwgetscript wwgetnodeconfig wwgetvnfs register functions wwgetfi
 
 MAINTAINERCLEANFILES = Makefile.in
 
+MACHINE:=$(shell uname -m)
+
 TRANSPORT_NAME = http
 
 
@@ -17,11 +19,11 @@ capability.cpio: rootfs
 	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
 
 install-data-local: capability.cpio
-	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities
-	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/transport-http
+	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities
+	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/transport-http
 
 uninstall-local:
-	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/capabilities/transport-http
+	rm -rf $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/transport-http
 
 clean-local:
 	rm -rf rootfs capability.cpio

--- a/provision/warewulf-provision.spec.in
+++ b/provision/warewulf-provision.spec.in
@@ -128,13 +128,13 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) %{_sysconfdir}/httpd/conf.d/warewulf-httpd.conf
 %{_bindir}/*
 %attr(0750, root, apache) %{_libexecdir}/warewulf/cgi-bin/
-%{_datadir}/warewulf/ldlinux.c32
-%{_datadir}/warewulf/ldlinux.e32
-%{_datadir}/warewulf/ldlinux.e64
-%{_datadir}/warewulf/lpxelinux.0
-%{_datadir}/warewulf/pxelinux.0
-%{_datadir}/warewulf/syslinux32.efi
-%{_datadir}/warewulf/syslinux64.efi
+%{_datadir}/warewulf/%{_arch}/ldlinux.c32
+%{_datadir}/warewulf/%{_arch}/ldlinux.e32
+%{_datadir}/warewulf/%{_arch}/ldlinux.e64
+%{_datadir}/warewulf/%{_arch}/lpxelinux.0
+%{_datadir}/warewulf/%{_arch}/pxelinux.0
+%{_datadir}/warewulf/%{_arch}/syslinux32.efi
+%{_datadir}/warewulf/%{_arch}/syslinux64.efi
 %{perl_vendorlib}/Warewulf/Event/Bootstrap.pm
 %{perl_vendorlib}/Warewulf/Event/Dhcp.pm
 %{perl_vendorlib}/Warewulf/Event/Pxelinux.pm


### PR DESCRIPTION
syslinux (for now), the base rootfs and capability files are now installed under architectural specific directories, eg:

/usr/share/warewulf/x86_64
/var/warewulf/initramfs/x86_64

Various bits of code need to be updated to use this new path, but that will come as a separate PR. 

This is part of the effort to support ARM64: #35.