### PR TITLE
Approve distribution of iPXE within Warewulf

### DIFF
--- a/provision/3rd_party/GPL/README
+++ b/provision/3rd_party/GPL/README
@@ -19,3 +19,4 @@ Bradley M. Kuhn, Executive Director, Software Freedom Conservancy, Busybox
 H. Peter Anvin, Syslinux Project
 Theodore Ts'o, E2fsprogs
 David Cantrell, GNU parted
+Michael Brown, iPXE


### PR DESCRIPTION
As per discussion via e-mail, the distribution of iPXE as a standalone
component within Warewulf qualifies as "mere aggregation" under the
terms of the GPL and is in conformance with the licensing terms.

This is not a copyright waiver and does not modify the licensing terms
applicable to iPXE.

Signed-off-by: Michael Brown <mcb30@ipxe.org>