### PR TITLE
Use awk to check for a module in modules.dep, allowing for a compression filename suffix

### DIFF
--- a/provision/initramfs/detect
+++ b/provision/initramfs/detect
@@ -21,7 +21,9 @@ if [ ! -d /sys/bus/pci/devices ]; then
 fi
 
 modcheck() {
-    grep -q "/$1.ko:" /lib/modules/$KVERSION/modules.dep
+    awk "BEGIN { e=1 }
+         /\/$1.ko(:|.xz:|.bz:|.gz:)/ { e=0 }
+         END { exit e }" /lib/modules/$KVERSION/modules.dep
 }
 
 


### PR DESCRIPTION
Support kernel's with compressed kernel modules in the initramfs' detect script for use with wwkmods. The previous grep in modules.dep wouldn't allow for a compression suffix after .ko. 