### PR TITLE
Parted needs libuuid-devel, ipxe needs xz-devel, add both as BuildRequires

### DIFF
--- a/provision/warewulf-provision.spec.in
+++ b/provision/warewulf-provision.spec.in
@@ -12,8 +12,7 @@ Group: System Environment/Clustering
 Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
 Requires: warewulf-common
-BuildRequires: warewulf-common libselinux-devel libacl-devel libattr-devel device-mapper-devel
-
+BuildRequires: warewulf-common libselinux-devel libacl-devel libattr-devel libuuid-devel device-mapper-devel xz-devel
 
 %if 0%{?_cross_compile}
 


### PR DESCRIPTION
Missing BuildRequires in provision:

- Parted needs libuuid-devel
- ipxe needs xz-devel