### PR TITLE
Replace instances of calling make directly with $(MAKE)

### DIFF
--- a/ipmi/initramfs/Makefile.am
+++ b/ipmi/initramfs/Makefile.am
@@ -21,7 +21,7 @@ ipmitool:
 		fi; \
 	    cd _work/ipmitool/ipmitool-$(IPMITOOL_VERSION) ;\
 	    ./configure --enable-static --disable-ipmishell ;\
-	    make LDFLAGS=-static ;\
+	    $(MAKE) LDFLAGS=-static ;\
 	fi
 	@ if [ ! -f "unionfs" ]; then \
 	    cp -a _work/ipmitool/ipmitool-$(IPMITOOL_VERSION)/src/ipmitool ipmitool ;\

--- a/provision/3rd_party/Makefile.am
+++ b/provision/3rd_party/Makefile.am
@@ -21,25 +21,25 @@ prep:
 bin-i386-pcbios/undionly.kpxe: prep
 
 if BUILD_X86_64
-	make -C _work/$(IPXE_DIR)/src CROSS_COMPILE=$(CROSS_COMPILE_X86_64) bin-i386-pcbios/undionly.kpxe
+	$(MAKE) -C _work/$(IPXE_DIR)/src CROSS_COMPILE=$(CROSS_COMPILE_X86_64) bin-i386-pcbios/undionly.kpxe
 endif
 
 bin-x86_64-efi/ipxe.efi: prep
 
 if BUILD_X86_64
-	make -C _work/$(IPXE_DIR)/src CROSS_COMPILE=$(CROSS_COMPILE_X86_64) bin-x86_64-efi/ipxe.efi
+	$(MAKE) -C _work/$(IPXE_DIR)/src CROSS_COMPILE=$(CROSS_COMPILE_X86_64) bin-x86_64-efi/ipxe.efi
 endif
 
 bin-i386-efi/ipxe.efi: prep
 
 if BUILD_X86_64
-	make -C _work/$(IPXE_DIR)/src CROSS_COMPILE=$(CROSS_COMPILE_X86_64) bin-i386-efi/ipxe.efi
+	$(MAKE) -C _work/$(IPXE_DIR)/src CROSS_COMPILE=$(CROSS_COMPILE_X86_64) bin-i386-efi/ipxe.efi
 endif
 
 bin-arm64-efi/snp.efi: prep
 
 if BUILD_ARM64
-	make -C _work/$(IPXE_DIR)/src CROSS_COMPILE=$(CROSS_COMPILE_ARM64) bin-arm64-efi/snp.efi
+	$(MAKE) -C _work/$(IPXE_DIR)/src CROSS_COMPILE=$(CROSS_COMPILE_ARM64) bin-arm64-efi/snp.efi
 endif
 
 install-data-local: $(IPXETARGETS)

--- a/provision/initramfs/Makefile.am
+++ b/provision/initramfs/Makefile.am
@@ -41,7 +41,7 @@ e2fsprogs:
 			cp /usr/lib/rpm/config.sub _work/$(E2FSPROGS_DIR)/config;\
 		fi; \
 		(cd _work/$(E2FSPROGS_DIR)/; ./configure $(E2FSPROGS_CONFIGARGS)) ;\
-		make -C _work/$(E2FSPROGS_DIR);\
+		$(MAKE) -C _work/$(E2FSPROGS_DIR);\
 	fi
 
 
@@ -57,11 +57,11 @@ busybox:
 	fi
 	@ if [ ! -f "_work/$(BUSYBOX_DIR)/" ]; then \
 		echo "Building initramfs core" ;\
-		make -C _work/$(BUSYBOX_DIR) busybox ;\
+		$(MAKE) -C _work/$(BUSYBOX_DIR) busybox ;\
 	fi
 	@ if [ ! -d "_work/$(BUSYBOX_DIR)/_install" ]; then \
 		echo "Installing initramfs core" ;\
-		make -C _work/$(BUSYBOX_DIR) install ;\
+		$(MAKE) -C _work/$(BUSYBOX_DIR) install ;\
 	fi
 
 libarchive:
@@ -74,7 +74,7 @@ libarchive:
 	@ if [ ! -f "_work/$(LIBARCHIVE_DIR)/" ]; then \
 		echo "Building libarchive" ;\
 		(cd _work/$(LIBARCHIVE_DIR)/; ./configure $(LIBARCHIVE_CONFIGARGS)) ;\
-		make -C _work/$(LIBARCHIVE_DIR);\
+		$(MAKE) -C _work/$(LIBARCHIVE_DIR);\
 	fi
 
 parted:
@@ -87,7 +87,7 @@ parted:
 	@ if [ ! -f "_work/$(PARTED_DIR)/" ]; then \
 		echo "Building parted" ;\
 		(cd _work/$(PARTED_DIR)/; ./configure $(PARTED_CONFIGARGS)) ;\
-		make -C _work/$(PARTED_DIR);\
+		$(MAKE) -C _work/$(PARTED_DIR);\
 	fi
 
 rootfs: busybox e2fsprogs libarchive parted
@@ -107,7 +107,7 @@ rootfs: busybox e2fsprogs libarchive parted
 	cp _work/$(E2FSPROGS_DIR)/misc/mke2fs rootfs/sbin/mkfs.ext4
 	ln -s mkfs.ext4 rootfs/sbin/mkfs.ext3
 	cp -a _work/$(LIBARCHIVE_DIR)/bsdtar rootfs/bin/bsdtar
-	make -C _work/$(PARTED_DIR)/ DESTDIR=`pwd`/rootfs install
+	$(MAKE) -C _work/$(PARTED_DIR)/ DESTDIR=`pwd`/rootfs install
 	cp -L --parents /lib*/ld-linux* rootfs/
 	find rootfs -type f -perm -o+x -print | grep -v ld-linux | xargs ldd | grep "=>" | awk '{print $$3}' | grep "^/" | sort | uniq | while read i; do cp -L --parents $$i rootfs/ && chmod 755 rootfs/$$i; done
 	rm -f rootfs/linuxrc rootfs/lib64/*.la rootfs/lib/*.la rootfs/usr/lib64/*.la rootfs/usr/lib/*.la

--- a/provision/initramfs/capabilities/provision-unionfs/Makefile.am
+++ b/provision/initramfs/capabilities/provision-unionfs/Makefile.am
@@ -17,7 +17,7 @@ unionfs:
 	fi
 	@ if [ ! -f "_work/unionfs-fuse/unionfs-fuse-$(UNIONFS_VERSION)/src/unionfs" ]; then \
 	    echo "Building unionfs-fuse" ;\
-	    make -C _work/unionfs-fuse/unionfs-fuse-$(UNIONFS_VERSION) ;\
+	    $(MAKE) -C _work/unionfs-fuse/unionfs-fuse-$(UNIONFS_VERSION) ;\
 	fi
 	@ if [ ! -f "unionfs" ]; then \
 	    cp -a _work/unionfs-fuse/unionfs-fuse-$(UNIONFS_VERSION)/src/unionfs unionfs ;\


### PR DESCRIPTION
"Recursive make commands should always use the variable MAKE, not the explicit command name ‘make’"

Ref: https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html