### PR TITLE
Fix empty file test in database init

### DIFF
--- a/common/libexec/wwinit/10-database.init
+++ b/common/libexec/wwinit/10-database.init
@@ -162,7 +162,7 @@ if [ "$DATASTORE" = "mysql" ]; then
     else
         wwprint "Database version: UNDEF (need to create database)\n"
         perl -e 'use Warewulf::DataStore::SQL::MySQL;print Warewulf::DataStore::SQL::MySQL->database_schema_string();' > "${SCRIPT_TMPDIR}/schema"
-        if [ $? -eq 0 -a -f "${SCRIPT_TMPDIR}/schema" -a $(wc -l "${SCRIPT_TMPDIR}/schema") ]; then
+        if [ $? -eq 0 -a -f "${SCRIPT_TMPDIR}/schema" -a -s "${SCRIPT_TMPDIR}/schema" ]; then
             wwprint "Creating database schema"
             wwrun mysql $CLI_ARGS "$DBNAME" < "${SCRIPT_TMPDIR}/schema" || exit 255
         else


### PR DESCRIPTION
"wwinit database" was failing when creating a new database because the
test using "wc" was failing with syntax error in Bash. Since what we
want to know is that the file exists and has something in it, a simple
"-s" should suffice.

Tested locally and it passed that point, whereas before it was failing
with error:

/usr/libexec/warewulf/wwinit/10-database.init: line 167:
[: too many arguments
Lethal error thrown by module:
/usr/libexec/warewulf/wwinit/10-database.init