### PR TITLE
Rename Pxelinux based modules to Pxe, move bootstrap and iPXE configs into statedir/warewulf/{bootstrap,ipxe}.

### DIFF
--- a/provision/etc/dhcpd-template.conf
+++ b/provision/etc/dhcpd-template.conf
@@ -12,7 +12,7 @@ option ipxe.no-pxedhcp 1;
 option architecture-type   code 93  = unsigned integer 16;
 
 if exists user-class and option user-class = "iPXE" {
-    filename "/warewulf/ipxe/cfg/${mac}";
+    filename "http://%{IPADDR}/WW/ipxe/cfg/${mac}";
 } else {
     if option architecture-type = 00:0B {
         filename "/warewulf/ipxe/bin-arm64-efi/snp.efi";

--- a/provision/etc/warewulf-httpd.conf.in
+++ b/provision/etc/warewulf-httpd.conf.in
@@ -13,7 +13,8 @@ PerlSwitches -I/var/www/stage/cgi-bin
 
 Alias /WW/static @fulldatadir@/warewulf/www
 Alias /WW/vnfs_cache /var/tmp/warewulf_cache
-Alias /WW/boot /var/lib/tftpboot
+Alias /WW/ipxe @WAREWULF_STATEDIR@/warewulf/ipxe
+Alias /WW/bootstrap @WAREWULF_STATEDIR@/warewulf/bootstrap
 
 ScriptAlias /WW/file @fulllibexecdir@/warewulf/cgi-bin/file.pl
 ScriptAlias /WW/script @fulllibexecdir@/warewulf/cgi-bin/script.pl
@@ -53,10 +54,18 @@ ScriptAlias /WW/vnfs @fulllibexecdir@/warewulf/cgi-bin/vnfs.pl
     </IfVersion>
 </Directory>
 
-# If selinux is enforcing run the following to allow httpd access:
-# semanage fcontext -a -t public_content_t '/var/lib/tftpboot(/.*)?'
-# restorecon -Rv /var/lib/tftpboot
-<Directory /var/lib/tftpboot>
+<Directory @WAREWULF_STATEDIR@/warewulf/ipxe>
+    AllowOverride None
+    <IfVersion < 2.4>
+        Order allow,deny
+        Allow from all
+    </IfVersion>
+    <IfVersion >= 2.4>
+        Require all granted
+    </IfVersion>
+</Directory>
+
+<Directory @WAREWULF_STATEDIR@/warewulf/bootstrap>
     AllowOverride None
     <IfVersion < 2.4>
         Order allow,deny

--- a/provision/lib/Warewulf/Bootstrap.pm
+++ b/provision/lib/Warewulf/Bootstrap.pm
@@ -14,7 +14,6 @@ use Warewulf::Object;
 use Warewulf::Logger;
 use Warewulf::DataStore;
 use Warewulf::Util;
-use Warewulf::Provision::Tftp;
 use File::Basename;
 use File::Path;
 use Digest::MD5 qw(md5_hex);
@@ -247,9 +246,9 @@ delete_local_bootstrap()
         &dprint("Going to delete bootstrap: $bootstrap_name\n");
 
         if ($bootstrap_id =~ /^([0-9]+)$/ && $arch) {
-            my $id = $1;
-            my $tftpboot = Warewulf::Provision::Tftp->new()->tftpdir();
-            my $bootstrapdir = "$tftpboot/warewulf/bootstrap/$arch/$bootstrap_id/";
+            my $bootstrap_id = $1;
+            my $statedir = &Warewulf::ACVars::get("statedir");
+            my $bootstrapdir = "$statedir/warewulf/bootstrap/$arch/$bootstrap_id/";
 
             &nprint("Deleting local bootable bootstrap files: $bootstrap_name\n");
 
@@ -291,7 +290,7 @@ delete_local_bootstrap()
 
 =item build_local_bootstrap()
 
-Write the bootstrap image to the TFTP directory. This does more then just pull
+Write the bootstrap image to the $statedir/warewulf directory. This does more then just pull
 it out of the data store and dump it to a file. It also merges it with the
 appropriate Warewulf initrd userspace components for the provision master in
 question.
@@ -322,18 +321,15 @@ build_local_bootstrap()
             return();
         }
 
-# TODO: Integration of capabilities should be done when a bootstrap image is
-# first imported.
-
         if ($bootstrap_id =~ /^([0-9]+)$/) {
-            my $id = $1;
+            my $bootstrap_id = $1;
             my $ds = Warewulf::DataStore->new();
-            my $tftpboot = Warewulf::Provision::Tftp->new()->tftpdir();
-            my $initramfsdir = &Warewulf::ACVars::get("statedir") . "/warewulf/initramfs/$arch";
+            my $statedir = &Warewulf::ACVars::get("statedir");
+            my $initramfsdir = $statedir . "/warewulf/initramfs/$arch";
             my $randstring = &rand_string("12");
             my $tmpdir = "/var/tmp/wwinitrd.$randstring";
             my $binstore = $ds->binstore($bootstrap_id);
-            my $bootstrapdir = "$tftpboot/warewulf/bootstrap/$arch/$bootstrap_id/";
+            my $bootstrapdir = "$statedir/warewulf/bootstrap/$arch/$bootstrap_id/";
             my $initramfs = "$initramfsdir/initfs";
 
             &nprint("Integrating the Warewulf bootstrap: $bootstrap_name\n");

--- a/provision/lib/Warewulf/Event/Makefile.am
+++ b/provision/lib/Warewulf/Event/Makefile.am
@@ -1,6 +1,6 @@
 perlmodsdir = ${PERL_VENDORLIB}/Warewulf/Event
 
-dist_perlmods_SCRIPTS = DefaultProvisionNode.pm Dhcp.pm Pxelinux.pm DynamicHosts.pm Bootstrap.pm ProvisionFileDelete.pm
+dist_perlmods_SCRIPTS = DefaultProvisionNode.pm Dhcp.pm Pxe.pm DynamicHosts.pm Bootstrap.pm ProvisionFileDelete.pm
 
 MAINTAINERCLEANFILES = Makefile.in
 

--- a/provision/lib/Warewulf/Event/Pxe.pm
+++ b/provision/lib/Warewulf/Event/Pxe.pm
@@ -8,17 +8,17 @@
 # $Id: Pxelinux.pm 50 2010-11-02 01:15:57Z gmk $
 #
 
-package Warewulf::Event::Pxelinux;
+package Warewulf::Event::Pxe;
 
 use Warewulf::Event;
 use Warewulf::EventHandler;
 use Warewulf::Logger;
-use Warewulf::Provision::Pxelinux;
+use Warewulf::Provision::Pxe;
 use Warewulf::RetVal;
 
 
 my $event = Warewulf::EventHandler->new();
-my $pxe = Warewulf::Provision::Pxelinux->new();
+my $pxe = Warewulf::Provision::Pxe->new();
 
 
 sub

--- a/provision/lib/Warewulf/Module/Cli/Pxe.pm
+++ b/provision/lib/Warewulf/Module/Cli/Pxe.pm
@@ -13,7 +13,7 @@ package Warewulf::Module::Cli::Pxe;
 use Warewulf::Logger;
 use Warewulf::DataStore;
 use Warewulf::Util;
-use Warewulf::Provision::Pxelinux;
+use Warewulf::Provision::Pxe;
 use Getopt::Long;
 
 
@@ -87,7 +87,7 @@ sub
 exec()
 {
     my $self = shift;
-    my $pxe = Warewulf::Provision::Pxelinux->new();
+    my $pxe = Warewulf::Provision::Pxe->new();
     my $db = Warewulf::DataStore->new();
     my $opt_lookup = "name";
 

--- a/provision/lib/Warewulf/Provision/Makefile.am
+++ b/provision/lib/Warewulf/Provision/Makefile.am
@@ -2,7 +2,7 @@ SUBDIRS = Dhcp
 
 perlmodsdir = ${PERL_VENDORLIB}/Warewulf/Provision
 
-dist_perlmods_SCRIPTS = Dhcp.pm DhcpFactory.pm Pxelinux.pm Tftp.pm HostsFile.pm
+dist_perlmods_SCRIPTS = Dhcp.pm DhcpFactory.pm Pxe.pm Tftp.pm HostsFile.pm
 
 MAINTAINERCLEANFILES = Makefile.in
 

--- a/provision/warewulf-provision.spec.in
+++ b/provision/warewulf-provision.spec.in
@@ -46,8 +46,6 @@ Summary: Warewulf - Provisioning Module - Server
 Group: System Environment/Clustering
 Requires: %{name} = %{version}-%{release}
 Requires: mod_perl httpd tftp-server dhcp
-Requires(post): policycoreutils-python
-Requires(postun): policycoreutils-python
 
 %description server
 Warewulf >= 3 is a set of utilities designed to better enable
@@ -85,6 +83,8 @@ Summary: This package sets up the selinux policy to allow HTTPD access to Warewu
 
 Group: Development/System
 Requires: %{name} = %{version}-%{release}
+Requires(post): policycoreutils-python
+Requires(postun): policycoreutils-python
 
 %description server-selinux
 Warewulf >= 3 is a set of utilities designed to better enable

--- a/provision/warewulf-provision.spec.in
+++ b/provision/warewulf-provision.spec.in
@@ -46,6 +46,8 @@ Summary: Warewulf - Provisioning Module - Server
 Group: System Environment/Clustering
 Requires: %{name} = %{version}-%{release}
 Requires: mod_perl httpd tftp-server dhcp
+Requires(post): policycoreutils-python
+Requires(postun): policycoreutils-python
 
 %description server
 Warewulf >= 3 is a set of utilities designed to better enable
@@ -116,7 +118,19 @@ chkconfig tftp on >/dev/null 2>&1 || :
 chkconfig xinetd on >/dev/null 2>&1 || :
 service xinetd reload >/dev/null 2>&1 || service xinetd restart >/dev/null 2>&1 || :
 %endif
+mkdir -p %{_localstatedir}/warewulf/ipxe %{_localstatedir}/warewulf/bootstrap 2>/dev/null || :
+semanage fcontext -a -t httpd_sys_content_t '%{_localstatedir}/warewulf/ipxe(/.*)?' 2>/dev/null || :
+semanage fcontext -a -t httpd_sys_content_t '%{_localstatedir}/warewulf/bootstrap(/.*)?' 2>/dev/null || :
+restorecon -R %{_localstatedir}/warewulf/bootstrap || :
+restorecon -R %{_localstatedir}/warewulf/ipxe || :
 
+
+
+%postun server
+if [ $1 -eq 0 ] ; then
+semanage fcontext -d -t httpd_sys_content_t '%{_localstatedir}/warewulf/ipxe(/.*)?' 2>/dev/null || :
+semanage fcontext -d -t httpd_sys_content_t '%{_localstatedir}/warewulf/bootstrap(/.*)?' 2>/dev/null || :
+fi
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/provision/warewulf-provision.spec.in
+++ b/provision/warewulf-provision.spec.in
@@ -152,7 +152,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/warewulf/ipxe/*
 %{perl_vendorlib}/Warewulf/Event/Bootstrap.pm
 %{perl_vendorlib}/Warewulf/Event/Dhcp.pm
-%{perl_vendorlib}/Warewulf/Event/Pxelinux.pm
+%{perl_vendorlib}/Warewulf/Event/Pxe.pm
 %{perl_vendorlib}/Warewulf/Module/Cli/Pxe.pm
 %{perl_vendorlib}/Warewulf/Module/Cli/Dhcp.pm
 

--- a/provision/warewulf-provision.spec.in
+++ b/provision/warewulf-provision.spec.in
@@ -80,6 +80,19 @@ Public License (GPL).
 In order to be 100% compatible with the GPL this package makes
 available the included GPL software.
 
+%package server-selinux
+Summary: This package sets up the selinux policy to allow HTTPD access to Warewulf state directories
+
+Group: Development/System
+Requires: %{name} = %{version}-%{release}
+
+%description server-selinux
+Warewulf >= 3 is a set of utilities designed to better enable
+utilization and maintenance of clusters or groups of computers.  The
+provision module provides functionality for provisioning, configuring,
+and booting systems.
+
+This package sets up the selinux policy to allow HTTPD access to Warewulf state directories
 
 %prep
 %setup -q
@@ -118,15 +131,15 @@ chkconfig tftp on >/dev/null 2>&1 || :
 chkconfig xinetd on >/dev/null 2>&1 || :
 service xinetd reload >/dev/null 2>&1 || service xinetd restart >/dev/null 2>&1 || :
 %endif
+
+%post server-selinux
 mkdir -p %{_localstatedir}/warewulf/ipxe %{_localstatedir}/warewulf/bootstrap 2>/dev/null || :
 semanage fcontext -a -t httpd_sys_content_t '%{_localstatedir}/warewulf/ipxe(/.*)?' 2>/dev/null || :
 semanage fcontext -a -t httpd_sys_content_t '%{_localstatedir}/warewulf/bootstrap(/.*)?' 2>/dev/null || :
 restorecon -R %{_localstatedir}/warewulf/bootstrap || :
 restorecon -R %{_localstatedir}/warewulf/ipxe || :
 
-
-
-%postun server
+%postun server-selinux
 if [ $1 -eq 0 ] ; then
 semanage fcontext -d -t httpd_sys_content_t '%{_localstatedir}/warewulf/ipxe(/.*)?' 2>/dev/null || :
 semanage fcontext -d -t httpd_sys_content_t '%{_localstatedir}/warewulf/bootstrap(/.*)?' 2>/dev/null || :
@@ -174,5 +187,7 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-, root, root)
 %{_prefix}/src/warewulf/3rd_party/GPL/
 
+%files server-selinux
+%defattr(-, root, root)
 
 %changelog


### PR DESCRIPTION
Closes #65.
Closes #58.

- Rename Warewulf::Event::Pxelinux to Warewulf::Event::Pxe 
- Rename Warewulf::Provision::Pxelinux to Warewulf::Provision::Pxe
- Bootstraps now saved under WAREWULF_STATEDIR{/var}/warewulf/bootstrap
- iPXE Cfg files now saved under WAREWULF_STATEDIR{/var}/warewulf/ipxe
- warewulf-httpd.conf.in updated to serve new directories as /WW/bootstrap and /WW/ipxe
- Warewulf::Provision::Pxe updated to generate iPXE configs using new URLs
- dhcpd-template.conf updated to specify the iPXE cfg as http://%{IPADDR}/WW/ipxe/cfg/${mac}, now serving the iPXE config files over HTTP instead of TFTP
- Warewulf::Provision::Pxe delete() updated to remove iPXE cfgs, not old pxelinux paths.
- Creates a new warewulf-server-selinux RPM that `mkdir -p /var/warewulf/{ipxe,bootstrap}` and sets the selinux target of the directories to `httpd_sys_content_t` to allow httpd access. This package requires `policycoreutils-python`, and is only required for master hosts with selinux set to enforcing.
