### PR TITLE
Add DBD::Pg and DBD::SQLite as dependancies of warewulf-common

### DIFF
--- a/common/warewulf-common.spec.in
+++ b/common/warewulf-common.spec.in
@@ -11,7 +11,7 @@ ExclusiveOS: linux
 Conflicts: warewulf <= 2.9
 BuildArch: noarch
 BuildRoot: %{?_tmppath}/%{name}-%{version}-%{release}-root
-Requires: perl-DBD-MySQL
+Requires: perl-DBD-MySQL perl-DBD-Pg perl-DBD-SQLite
 %if %{?rhel}%{!?rhel:0} >= 7
 Requires: mariadb
 %else


### PR DESCRIPTION
Rpmbuild wasn't picking up DBD::SQLite automatically, so adding perl-DBB-SQLite and perl-DBD-Pg explicitly as dependancies. 

I'm thinking this is good enough to close #49. MySQL/MariaDB is still the default database, and I don't think we need to split out the database drivers into individual packages.