### PR TITLE
Wwinit tftp.socket, systemd socket unit support

### DIFF
--- a/cluster/libexec/wwinit/50-tftp.init
+++ b/cluster/libexec/wwinit/50-tftp.init
@@ -21,7 +21,7 @@ fi
 wwreqroot
 
 if wwpackage_check tftp-server tftpd tftpd-hpa; then
-    if wwservice_activate tftpd tftp tftpd-hpa; then
+    if wwservice_activate tftp.socket tftpd tftp tftpd-hpa; then
         exit 0
     fi
 fi

--- a/common/etc/functions
+++ b/common/etc/functions
@@ -232,16 +232,19 @@ wwpackage_check() {
 # that have different service names for the same service (e.g. ntp and
 # ntpd).
 wwservice_activate() {
-    if test -x "/bin/initctl" || test -x "/usr/sbin/update-rc.d" ; then
-        # We need to add entries for initctl and update-rc.d below! HELP!
-        wwprint "You will need to manually enable and (re)start: $@\n" warn
-    fi
     for SERVICE in "$@"; do
-        if [ -e "/etc/xinetd.d/$SERVICE" ]; then
-            wwprint "Activating xinetd service: $1\n"
-            wwrun sed -ie 's@\(disable\s*=\s*\)\S*@\1no@' /etc/xinetd.d/$SERVICE
-            wwservice_activate xinetd
-            return 0
+        if [ -x "/bin/systemctl" ]; then
+            if ! echo $SERVICE | egrep -q '\.service$|\.socket$'; then
+                SERVICE="${SERVICE}.service"
+            fi
+            if systemctl list-unit-files --type=service,socket | egrep -q "^$SERVICE"; then
+                wwprint "Activating Systemd unit: $1\n"
+                if wwrun /bin/systemctl -q enable $SERVICE; then
+                    if wwrun /bin/systemctl -q restart $SERVICE; then
+                        return 0
+                    fi
+                fi
+            fi
         elif [ -x "/etc/rc.d/init.d/$SERVICE" ]; then
             wwprint "Activating system service: $1\n"
             if [ -x "/sbin/chkconfig" ]; then
@@ -255,13 +258,11 @@ wwservice_activate() {
             if wwrun /etc/init.d/$SERVICE restart; then
                 return 0
             fi
-        elif test -x "/bin/systemctl" && systemctl list-unit-files --type=service | egrep -q "^$SERVICE.service"; then
-            wwprint "Activating Systemd service: $1\n"
-            if wwrun /bin/systemctl -q enable $SERVICE.service; then
-                if wwrun /bin/systemctl -q restart $SERVICE.service; then
-                    return 0
-                fi
-            fi
+        elif [ -e "/etc/xinetd.d/$SERVICE" ]; then
+            wwprint "Activating xinetd service: $1\n"
+            wwrun sed -ie 's@\(disable\s*=\s*\)\S*@\1no@' /etc/xinetd.d/$SERVICE
+            wwservice_activate xinetd
+            return 0
         fi
     done
 


### PR DESCRIPTION
- Add support for using systemd socket units
- Move xinetd to last service order behind systemd and sysv init script
- Remove warning around update-rc.d and initctl
- Add system unit tftp.socket to match the warewulf-provision-server RPM postscript. This is used instead of xinetd in RHEL7

Closes #71 