### PR TITLE
Merge provision-server-selinux sub-package into provision-server package

### DIFF
--- a/provision/warewulf-provision.spec.in
+++ b/provision/warewulf-provision.spec.in
@@ -45,7 +45,7 @@ administrative tools.  To actually provision systems, the
 Summary: Warewulf - Provisioning Module - Server
 Group: System Environment/Clustering
 Requires: %{name} = %{version}-%{release}
-Requires: mod_perl httpd tftp-server dhcp
+Requires: mod_perl httpd tftp-server dhcp policycoreutils-python
 
 %description server
 Warewulf >= 3 is a set of utilities designed to better enable
@@ -77,22 +77,6 @@ Public License (GPL).
 
 In order to be 100% compatible with the GPL this package makes
 available the included GPL software.
-
-%package server-selinux
-Summary: This package sets up the selinux policy to allow HTTPD access to Warewulf state directories
-
-Group: Development/System
-Requires: %{name} = %{version}-%{release}
-Requires(post): policycoreutils-python
-Requires(postun): policycoreutils-python
-
-%description server-selinux
-Warewulf >= 3 is a set of utilities designed to better enable
-utilization and maintenance of clusters or groups of computers.  The
-provision module provides functionality for provisioning, configuring,
-and booting systems.
-
-This package sets up the selinux policy to allow HTTPD access to Warewulf state directories
 
 %prep
 %setup -q
@@ -132,14 +116,13 @@ chkconfig xinetd on >/dev/null 2>&1 || :
 service xinetd reload >/dev/null 2>&1 || service xinetd restart >/dev/null 2>&1 || :
 %endif
 
-%post server-selinux
 mkdir -p %{_localstatedir}/warewulf/ipxe %{_localstatedir}/warewulf/bootstrap 2>/dev/null || :
 semanage fcontext -a -t httpd_sys_content_t '%{_localstatedir}/warewulf/ipxe(/.*)?' 2>/dev/null || :
 semanage fcontext -a -t httpd_sys_content_t '%{_localstatedir}/warewulf/bootstrap(/.*)?' 2>/dev/null || :
 restorecon -R %{_localstatedir}/warewulf/bootstrap || :
 restorecon -R %{_localstatedir}/warewulf/ipxe || :
 
-%postun server-selinux
+%postun server
 if [ $1 -eq 0 ] ; then
 semanage fcontext -d -t httpd_sys_content_t '%{_localstatedir}/warewulf/ipxe(/.*)?' 2>/dev/null || :
 semanage fcontext -d -t httpd_sys_content_t '%{_localstatedir}/warewulf/bootstrap(/.*)?' 2>/dev/null || :
@@ -186,8 +169,5 @@ rm -rf $RPM_BUILD_ROOT
 %files gpl_sources
 %defattr(-, root, root)
 %{_prefix}/src/warewulf/3rd_party/GPL/
-
-%files server-selinux
-%defattr(-, root, root)
 
 %changelog


### PR DESCRIPTION
Closes #72.

- Merge provision-server-selinux sub-package into provision-server package. 
- Adds policycoreutils-python as a dependency to warewulf-provision-server.