### PR TITLE
Remove generation of SSHv1 host keys

### DIFF
--- a/cluster/libexec/wwinit/50-ssh_keys.init
+++ b/cluster/libexec/wwinit/50-ssh_keys.init
@@ -46,7 +46,6 @@ wwprint "Checking root's ssh config"
 if ! wwtest test -f "$HOME/.ssh/config"; then
     wwprint "Creating ssh configuration for root"
     echo "Host *" >> $HOME/.ssh/config
-    echo "   IdentityFile ~/.ssh/identity" >> $HOME/.ssh/config
     echo "   IdentityFile ~/.ssh/id_rsa" >> $HOME/.ssh/config
     echo "   IdentityFile ~/.ssh/id_dsa" >> $HOME/.ssh/config
     echo "   IdentityFile ~/.ssh/cluster" >> $HOME/.ssh/config
@@ -56,19 +55,6 @@ if ! wwtest test -f "$HOME/.ssh/config"; then
     reply_done
 fi
 
-
-wwprint "Checking for default RSA1 host key for nodes"
-if ! wwtest test -f "$WAREWULF_SYSCONFDIR/warewulf/vnfs/ssh/ssh_host_key"; then
-    install -d -m 700 $WAREWULF_SYSCONFDIR/warewulf/vnfs/ssh
-    wwprint "Creating default node ssh_host_key:\n"
-    if ! ssh-keygen -q -t rsa1 -f $WAREWULF_SYSCONFDIR/warewulf/vnfs/ssh/ssh_host_key -C '' -N '' 2>/dev/null; then
-        wwprint "RSA1 key is not supported on your system" yellow
-        reply_warn
-    else
-	reply_ok
-    fi
-    RETVAL=0
-fi
 
 wwprint "Checking for default RSA host key for nodes"
 if ! wwtest test -f "$WAREWULF_SYSCONFDIR/warewulf/vnfs/ssh/ssh_host_rsa_key"; then

--- a/docs/recipes/setup/initialization.md
+++ b/docs/recipes/setup/initialization.md
@@ -35,9 +35,6 @@ ntpd:          + chkconfig ntpd on                                           OK
 ntpd:          + service ntpd restart                                        OK
 ssh_keys:     Checking ssh keys for root                                     OK
 ssh_keys:     Checking root's ssh config                                     OK
-ssh_keys:     Checking for default RSA1 host key for nodes                   NO
-ssh_keys:     Creating default node ssh_host_key:
-ssh_keys:      + ssh-keygen -q -t rsa1 -f /etc/warewulf/vnfs/ssh/ssh_host_ke OK
 ssh_keys:     Checking for default RSA host key for nodes                    NO
 ssh_keys:     Creating default node ssh_host_rsa_key:
 ssh_keys:      + ssh-keygen -q -t rsa -f /etc/warewulf/vnfs/ssh/ssh_host_rsa OK

--- a/vnfs/bin/mkchroot-debian.sh
+++ b/vnfs/bin/mkchroot-debian.sh
@@ -40,7 +40,6 @@ echo "sysfs /sys sysfs defaults 0 0" >> $VNFSDIR/etc/fstab
 echo "proc /proc proc defaults 0 0" >> $VNFSDIR/etc/fstab
 
 echo "Creating SSH host keys"
-/usr/bin/ssh-keygen -q -t rsa1 -f $VNFSDIR/etc/ssh/ssh_host_key -C '' -N ''
 /usr/bin/ssh-keygen -q -t rsa -f $VNFSDIR/etc/ssh/ssh_host_rsa_key -C '' -N ''
 /usr/bin/ssh-keygen -q -t dsa -f $VNFSDIR/etc/ssh/ssh_host_dsa_key -C '' -N ''
 

--- a/vnfs/bin/mkchroot-mud.sh
+++ b/vnfs/bin/mkchroot-mud.sh
@@ -1237,7 +1237,6 @@ EOF
 ###############################################################################
 
 	echo "Generate Random SSH Host Keys"
-	/usr/bin/ssh-keygen -q -t rsa1 -f ${VNFSROOT}/${NAME}/etc/ssh/ssh_host_key -C '' -N ''
 	/usr/bin/ssh-keygen -q -t rsa -f ${VNFSROOT}/${NAME}/etc/ssh/ssh_host_rsa_key -C '' -N ''
 	/usr/bin/ssh-keygen -q -t dsa -f ${VNFSROOT}/${NAME}/etc/ssh/ssh_host_dsa_key -C '' -N ''
 

--- a/vnfs/bin/mkchroot-rh.sh
+++ b/vnfs/bin/mkchroot-rh.sh
@@ -50,7 +50,6 @@ echo "proc /proc proc defaults 0 0" >> $VNFSDIR/etc/fstab
 echo "NETWORKING=yes" > $VNFSDIR/etc/sysconfig/network
 
 echo "Creating SSH host keys"
-/usr/bin/ssh-keygen -q -t rsa1 -f $VNFSDIR/etc/ssh/ssh_host_key -C '' -N ''
 /usr/bin/ssh-keygen -q -t rsa -f $VNFSDIR/etc/ssh/ssh_host_rsa_key -C '' -N ''
 /usr/bin/ssh-keygen -q -t dsa -f $VNFSDIR/etc/ssh/ssh_host_dsa_key -C '' -N ''
 

--- a/vnfs/bin/mkchroot-ubuntu.sh
+++ b/vnfs/bin/mkchroot-ubuntu.sh
@@ -41,7 +41,6 @@ echo "sysfs /sys sysfs defaults 0 0" >> $VNFSDIR/etc/fstab
 echo "proc /proc proc defaults 0 0" >> $VNFSDIR/etc/fstab
 
 echo "Creating SSH host keys"
-/usr/bin/ssh-keygen -q -t rsa1 -f $VNFSDIR/etc/ssh/ssh_host_key -C '' -N ''
 /usr/bin/ssh-keygen -q -t rsa -f $VNFSDIR/etc/ssh/ssh_host_rsa_key -C '' -N ''
 /usr/bin/ssh-keygen -q -t dsa -f $VNFSDIR/etc/ssh/ssh_host_dsa_key -C '' -N ''
 

--- a/vnfs/etc/wwmkchroot.tmpl
+++ b/vnfs/etc/wwmkchroot.tmpl
@@ -79,6 +79,9 @@ configure_fstab() {
 
 configure_sshkeys() {
     echo "Creating SSH host keys"
+    # SSHv1 is old and busted, but if you need it, uncomment this to
+    # generate a SSHv1 RSA host key
+    #/usr/bin/ssh-keygen -q -t rsa1 -f $VNFSDIR/etc/ssh/ssh_host_key -C '' -N ''
     /usr/bin/ssh-keygen -q -t rsa -f $VNFSDIR/etc/ssh/ssh_host_rsa_key -C '' -N ''
     /usr/bin/ssh-keygen -q -t dsa -f $VNFSDIR/etc/ssh/ssh_host_dsa_key -C '' -N ''
     return 0

--- a/vnfs/etc/wwmkchroot.tmpl
+++ b/vnfs/etc/wwmkchroot.tmpl
@@ -79,7 +79,6 @@ configure_fstab() {
 
 configure_sshkeys() {
     echo "Creating SSH host keys"
-    /usr/bin/ssh-keygen -q -t rsa1 -f $VNFSDIR/etc/ssh/ssh_host_key -C '' -N ''
     /usr/bin/ssh-keygen -q -t rsa -f $VNFSDIR/etc/ssh/ssh_host_rsa_key -C '' -N ''
     /usr/bin/ssh-keygen -q -t dsa -f $VNFSDIR/etc/ssh/ssh_host_dsa_key -C '' -N ''
     return 0

--- a/vnfs/libexec/wwmkchroot/functions
+++ b/vnfs/libexec/wwmkchroot/functions
@@ -161,12 +161,6 @@ configure_fstab() {
 }
 
 configure_sshkeys() {
-    # This should fail silently as RSA1 isn't supported on new platforms.
-    if [ -f "$WAREWULF_SYSCONFDIR/warewulf/vnfs/ssh/ssh_host_key" ]; then
-        /bin/cp -a $WAREWULF_SYSCONFDIR/warewulf/vnfs/ssh/ssh_host_key* $CHROOTDIR/etc/ssh/
-    elif [ ! -f "$CHROOTDIR/etc/ssh/ssh_host_key" ]; then
-        /usr/bin/ssh-keygen -q -t rsa1 -f $CHROOTDIR/etc/ssh/ssh_host_key -C '' -N '' 2> /dev/null
-    fi
     if [ -f "$WAREWULF_SYSCONFDIR/warewulf/vnfs/ssh/ssh_host_rsa_key" ]; then
         /bin/cp -a $WAREWULF_SYSCONFDIR/warewulf/vnfs/ssh/ssh_host_rsa_key* $CHROOTDIR/etc/ssh/
     elif [ ! -f "$CHROOTDIR/etc/ssh/ssh_host_rsa_key" ]; then


### PR DESCRIPTION
The SSHv1 protocol has been replaced by SSHv2 a long time ago, and
openssh has recently completely removed SSHv1 support.