### PR TITLE
Add support for SSH ed25519 host keys

### DIFF
--- a/cluster/libexec/wwinit/50-ssh_keys.init
+++ b/cluster/libexec/wwinit/50-ssh_keys.init
@@ -48,6 +48,7 @@ if ! wwtest test -f "$HOME/.ssh/config"; then
     echo "Host *" >> $HOME/.ssh/config
     echo "   IdentityFile ~/.ssh/identity" >> $HOME/.ssh/config
     echo "   IdentityFile ~/.ssh/id_rsa" >> $HOME/.ssh/config
+    echo "   IdentityFile ~/.ssh/id_ed25519" >> $HOME/.ssh/config
     echo "   IdentityFile ~/.ssh/id_dsa" >> $HOME/.ssh/config
     echo "   IdentityFile ~/.ssh/cluster" >> $HOME/.ssh/config
     echo "   StrictHostKeyChecking=no" >> $HOME/.ssh/config
@@ -103,5 +104,17 @@ if ! wwtest test -f "$WAREWULF_SYSCONFDIR/warewulf/vnfs/ssh/ssh_host_ecdsa_key";
     RETVAL=0
 fi
 
+wwprint "Checking for default Ed25519 host key for nodes"
+if ! wwtest test -f "$WAREWULF_SYSCONFDIR/warewulf/vnfs/ssh/ssh_host_ed25519_key"; then
+    install -d -m 700 $WAREWULF_SYSCONFDIR/warewulf/vnfs/ssh
+    wwprint "Creating default node ssh_host_ed25519_key:\n"
+    if ! ssh-keygen -q -t ed25519 -f $WAREWULF_SYSCONFDIR/warewulf/vnfs/ssh/ssh_host_ed25519_key -C '' -N '' 2>/dev/null; then
+        wwprint "Ed25519 key is not supported on your system" yellow
+        reply_warn
+    else
+	reply_ok
+    fi
+    RETVAL=0
+fi
 
 exit $RETVAL

--- a/vnfs/bin/mkchroot-debian.sh
+++ b/vnfs/bin/mkchroot-debian.sh
@@ -43,6 +43,7 @@ echo "Creating SSH host keys"
 /usr/bin/ssh-keygen -q -t rsa1 -f $VNFSDIR/etc/ssh/ssh_host_key -C '' -N ''
 /usr/bin/ssh-keygen -q -t rsa -f $VNFSDIR/etc/ssh/ssh_host_rsa_key -C '' -N ''
 /usr/bin/ssh-keygen -q -t dsa -f $VNFSDIR/etc/ssh/ssh_host_dsa_key -C '' -N ''
+/usr/bin/ssh-keygen -q -t ed25519 -f $VNFSDIR/etc/ssh/ssh_host_ed25519_key -C '' -N ''
 
 if [ ! -f "$VNFSDIR/etc/shadow" ]; then
 	echo "Creating show file"

--- a/vnfs/bin/mkchroot-mud.sh
+++ b/vnfs/bin/mkchroot-mud.sh
@@ -1240,6 +1240,7 @@ EOF
 	/usr/bin/ssh-keygen -q -t rsa1 -f ${VNFSROOT}/${NAME}/etc/ssh/ssh_host_key -C '' -N ''
 	/usr/bin/ssh-keygen -q -t rsa -f ${VNFSROOT}/${NAME}/etc/ssh/ssh_host_rsa_key -C '' -N ''
 	/usr/bin/ssh-keygen -q -t dsa -f ${VNFSROOT}/${NAME}/etc/ssh/ssh_host_dsa_key -C '' -N ''
+        /usr/bin/ssh-keygen -q -t ed25519 -f ${VNFSROOT}/${NAME}/etc/ssh/ssh_host_ed25519_key -C '' -N ''
 
 	if [ ! -f "${VNFSROOT}/${NAME}/etc/shadow" ]; then
 		echo "Creating shadow file"

--- a/vnfs/bin/mkchroot-rh.sh
+++ b/vnfs/bin/mkchroot-rh.sh
@@ -53,6 +53,7 @@ echo "Creating SSH host keys"
 /usr/bin/ssh-keygen -q -t rsa1 -f $VNFSDIR/etc/ssh/ssh_host_key -C '' -N ''
 /usr/bin/ssh-keygen -q -t rsa -f $VNFSDIR/etc/ssh/ssh_host_rsa_key -C '' -N ''
 /usr/bin/ssh-keygen -q -t dsa -f $VNFSDIR/etc/ssh/ssh_host_dsa_key -C '' -N ''
+/usr/bin/ssh-keygen -q -t ed25519 -f $VNFSDIR/etc/ssh/ssh_host_ed25519_key -C '' -N ''
 
 if [ ! -f "$VNFSDIR/etc/shadow" ]; then
     echo "Creating shadow file"

--- a/vnfs/bin/mkchroot-ubuntu.sh
+++ b/vnfs/bin/mkchroot-ubuntu.sh
@@ -44,6 +44,7 @@ echo "Creating SSH host keys"
 /usr/bin/ssh-keygen -q -t rsa1 -f $VNFSDIR/etc/ssh/ssh_host_key -C '' -N ''
 /usr/bin/ssh-keygen -q -t rsa -f $VNFSDIR/etc/ssh/ssh_host_rsa_key -C '' -N ''
 /usr/bin/ssh-keygen -q -t dsa -f $VNFSDIR/etc/ssh/ssh_host_dsa_key -C '' -N ''
+/usr/bin/ssh-keygen -q -t ed25519 -f $VNFSDIR/etc/ssh/ssh_host_ed25519_key -C '' -N ''
 
 if [ ! -f "$VNFSDIR/etc/shadow" ]; then
 	echo "Creating show file"

--- a/vnfs/etc/wwmkchroot.tmpl
+++ b/vnfs/etc/wwmkchroot.tmpl
@@ -82,6 +82,7 @@ configure_sshkeys() {
     /usr/bin/ssh-keygen -q -t rsa1 -f $VNFSDIR/etc/ssh/ssh_host_key -C '' -N ''
     /usr/bin/ssh-keygen -q -t rsa -f $VNFSDIR/etc/ssh/ssh_host_rsa_key -C '' -N ''
     /usr/bin/ssh-keygen -q -t dsa -f $VNFSDIR/etc/ssh/ssh_host_dsa_key -C '' -N ''
+    /usr/bin/ssh-keygen -q -t ed25519 -f $VNFSDIR/etc/ssh/ssh_host_ed25519_key -C '' -N ''
     return 0
 }
 

--- a/vnfs/libexec/wwmkchroot/functions
+++ b/vnfs/libexec/wwmkchroot/functions
@@ -185,6 +185,13 @@ configure_sshkeys() {
         /usr/bin/ssh-keygen -q -t ecdsa -f $CHROOTDIR/etc/ssh/ssh_host_ecdsa_key -C '' -N '' 2> /dev/null
     fi
 
+    # This should fail silently as Ed25519 isn't supported on older platforms.
+    if [ -f "$WAREWULF_SYSCONFDIR/warewulf/vnfs/ssh/ssh_host_ed25519_key" ]; then
+        /bin/cp -a $WAREWULF_SYSCONFDIR/warewulf/vnfs/ssh/ssh_host_ed25519_key* $CHROOTDIR/etc/ssh/
+    elif [ ! -f "$CHROOTDIR/etc/ssh/ssh_host_ed25519_key" ]; then
+        /usr/bin/ssh-keygen -q -t ed25519 -f $CHROOTDIR/etc/ssh/ssh_host_ed25519_key -C '' -N '' 2> /dev/null
+    fi
+
     mkdir -m 0700 -p $CHROOTDIR/root/.ssh 2>/dev/null
     > $CHROOTDIR/root/.ssh/authorized_keys
     for i in `ls /root/.ssh/*.pub 2>/dev/null`; do


### PR DESCRIPTION
Modern versions of openssh support a Ed25519 key type.