### PR TITLE
Generate RSA ssh keys for cluster access instead of DSA

### DIFF
--- a/cluster/bin/cluster-env
+++ b/cluster/bin/cluster-env
@@ -17,7 +17,7 @@ fi
 if [ ! -f "$HOME/.ssh/config" -a ! -f "$HOME/.ssh/cluster" ]; then
     echo "Configuring SSH for cluster access"
     install -d -m 700 $HOME/.ssh
-    ssh-keygen -t dsa -f $HOME/.ssh/cluster -N '' -C "Warewulf Cluster key" > /dev/null 2>&1
+    ssh-keygen -t rsa -f $HOME/.ssh/cluster -N '' -C "Warewulf Cluster key" > /dev/null 2>&1
     cat $HOME/.ssh/cluster.pub >> $HOME/.ssh/authorized_keys
     chmod 0600 $HOME/.ssh/authorized_keys
 

--- a/cluster/libexec/wwinit/50-ssh_keys.init
+++ b/cluster/libexec/wwinit/50-ssh_keys.init
@@ -32,7 +32,7 @@ fi
 wwprint "Checking ssh keys for root"
 if ! wwtest test -f "$HOME/.ssh/cluster"; then
     wwprint "Generating ssh keypairs for local cluster access:\n"
-    if ! wwrun ssh-keygen -t dsa -f $HOME/.ssh/cluster -N ''; then
+    if ! wwrun ssh-keygen -t rsa -f $HOME/.ssh/cluster -N ''; then
         exit 255
     fi
     wwprint "Updating authorized keys"


### PR DESCRIPTION
OpenSSH 7.0 disabled support for DSA keys by default. While support
can be reenabled via configuration, they were removed due to security
concerns, so it seems safer to switch to another algorithm. Ed25519
might in some sense be the best, but it's quite new and might thus not
yet be available on all distros Warewulf supports. So use RSA which is
good enough for now.

http://www.openssh.com/txt/release-7.0
http://www.openssh.com/legacy.html
https://meyering.net/nuke-your-DSA-keys/
https://security.stackexchange.com/questions/5096/rsa-vs-dsa-for-ssh-authentication-keys