### PR TITLE
Set broadcast address as well when setting ip

### DIFF
--- a/provision/initramfs/dhcp-script
+++ b/provision/initramfs/dhcp-script
@@ -11,7 +11,7 @@
 > /etc/network.conf
 
 if test -n "$ip"; then
-   ip address add $ip/$subnet dev $interface
+   ip address add $ip/$subnet broadcast + dev $interface
    echo "IPADDR=$ip" >> /etc/network.conf
    echo "NETMASK=$subnet" >> /etc/network.conf
 fi

--- a/provision/initramfs/init
+++ b/provision/initramfs/init
@@ -91,7 +91,7 @@ ifup() {
         if [ -n "$WWIPADDR" -a -n "$WWNETMASK" -a -n "$WWMASTER" ]; then
             msg_white "Configuring $DEVICE ($OSDEVICE) statically: "
             msg_gray "($WWIPADDR/$WWNETMASK)"
-            if ip address add $WWIPADDR/$WWNETMASK dev $DEVICE; then
+            if ip address add $WWIPADDR/$WWNETMASK broadcast + dev $DEVICE; then
                 wwsuccess
                 if [ -n "$WWGATEWAY" ]; then
                     msg_white "Configuring gateway: "


### PR DESCRIPTION
When using "ip address" to add an address to an interface, the
broadcast address needs to be explicitly set as well.