### PR TITLE
Use snp.efi instead of ipxe.efi for i386 and x86_64 UEFI boot

### DIFF
--- a/provision/3rd_party/Makefile.am
+++ b/provision/3rd_party/Makefile.am
@@ -1,6 +1,6 @@
 SUBDIRS = GPL BSD
 
-IPXETARGETS = bin-i386-pcbios/undionly.kpxe bin-x86_64-efi/ipxe.efi bin-i386-efi/ipxe.efi bin-arm64-efi/snp.efi
+IPXETARGETS = bin-i386-pcbios/undionly.kpxe bin-x86_64-efi/snp.efi bin-i386-efi/snp.efi bin-arm64-efi/snp.efi
 
 MAINTAINERCLEANFILES = Makefile.in
 
@@ -24,16 +24,16 @@ if BUILD_X86_64
 	$(MAKE) -C _work/$(IPXE_DIR)/src CROSS_COMPILE=$(CROSS_COMPILE_X86_64) bin-i386-pcbios/undionly.kpxe
 endif
 
-bin-x86_64-efi/ipxe.efi: prep
+bin-x86_64-efi/snp.efi: prep
 
 if BUILD_X86_64
-	$(MAKE) -C _work/$(IPXE_DIR)/src CROSS_COMPILE=$(CROSS_COMPILE_X86_64) bin-x86_64-efi/ipxe.efi
+	$(MAKE) -C _work/$(IPXE_DIR)/src CROSS_COMPILE=$(CROSS_COMPILE_X86_64) bin-x86_64-efi/snp.efi
 endif
 
-bin-i386-efi/ipxe.efi: prep
+bin-i386-efi/snp.efi: prep
 
 if BUILD_X86_64
-	$(MAKE) -C _work/$(IPXE_DIR)/src CROSS_COMPILE=$(CROSS_COMPILE_X86_64) bin-i386-efi/ipxe.efi
+	$(MAKE) -C _work/$(IPXE_DIR)/src CROSS_COMPILE=$(CROSS_COMPILE_X86_64) bin-i386-efi/snp.efi
 endif
 
 bin-arm64-efi/snp.efi: prep

--- a/provision/etc/dhcpd-template.conf
+++ b/provision/etc/dhcpd-template.conf
@@ -19,11 +19,11 @@ if exists user-class and option user-class = "iPXE" {
     } elsif option architecture-type = 00:0A {
         filename "/warewulf/ipxe/bin-arm32-efi/placeholder.efi";
     } elsif option architecture-type = 00:09 {
-        filename "/warewulf/ipxe/bin-x86_64-efi/ipxe.efi";
+        filename "/warewulf/ipxe/bin-x86_64-efi/snp.efi";
     } elsif option architecture-type = 00:07 {
-        filename "/warewulf/ipxe/bin-x86_64-efi/ipxe.efi";
+        filename "/warewulf/ipxe/bin-x86_64-efi/snp.efi";
     } elsif option architecture-type = 00:06 {
-        filename "/warewulf/ipxe/bin-i386-efi/ipxe.efi";
+        filename "/warewulf/ipxe/bin-i386-efi/snp.efi";
     } elsif option architecture-type = 00:00 {
         filename "/warewulf/ipxe/bin-i386-pcbios/undionly.kpxe";
     }

--- a/provision/lib/Warewulf/Provision/Pxe.pm
+++ b/provision/lib/Warewulf/Provision/Pxe.pm
@@ -84,7 +84,7 @@ setup()
     my $self = shift;
     my $datadir = &Warewulf::ACVars::get("datadir");
     my $tftpdir = Warewulf::Provision::Tftp->new()->tftpdir();
-    my @x86_tftpfiles = ("bin-i386-pcbios/undionly.kpxe", "bin-x86_64-efi/ipxe.efi", "bin-i386-efi/ipxe.efi");
+    my @x86_tftpfiles = ("bin-i386-pcbios/undionly.kpxe", "bin-x86_64-efi/snp.efi", "bin-i386-efi/snp.efi");
     my @aarch64_tftpfiles = ("bin-arm64-efi/snp.efi");
     my (undef, undef, undef, undef, $arch) = POSIX::uname();
 


### PR DESCRIPTION
This should fix https://github.com/warewulf/warewulf3/issues/84