### PR TITLE
Console can be removed from provision list

### DIFF
--- a/provision/lib/Warewulf/Module/Cli/Provision.pm
+++ b/provision/lib/Warewulf/Module/Cli/Provision.pm
@@ -604,7 +604,7 @@ exec()
         }
 
         if ($opt_console) {
-            if ($opt_console =~ /^(tty[S0-9]+\,[0-9]+)/) {
+            if ($opt_console =~ /^(tty[S0-9]+\,[0-9]+)/ || $opt_console =~ /^(UNDEF)$/) {
                 $opt_console = $1;
 
                 foreach my $obj ($objSet->get_list()) {


### PR DESCRIPTION
This fix allow to set

```
wwsh provistion nodexxx --console=UNDEF
```

which was not possible.