### PR TITLE
Exit 1 from iPXE to indicate an error, so system will properly continue to try other boot options

### DIFF
--- a/provision/lib/Warewulf/Provision/Pxe.pm
+++ b/provision/lib/Warewulf/Provision/Pxe.pm
@@ -268,7 +268,7 @@ update()
                 print IPXE "# Warewulf data store ID: $db_id\n";
                 if (defined($bootlocal) && $bootlocal eq -1) {
                     print IPXE "echo Set to bootlocal (exit), exiting iPXE to continue boot order\n";
-                    print IPXE "exit\n";
+                    print IPXE "exit 1\n";
                 } elsif (defined($bootlocal) && $bootlocal eq 0)  {
                     print IPXE "echo Set to bootlocal (normal), booting local disk\n";
                     print IPXE "sanboot --no-describe --drive 0x80\n";


### PR DESCRIPTION
Ref: http://ipxe.org/cmd/exit

On some machines I've tested exit 0 results in going into the UEFI setup page, where exit 1 continues the boot order.