### PR TITLE
Fix ignoring DHCP

### DIFF
--- a/common/bin/wwsh
+++ b/common/bin/wwsh
@@ -86,7 +86,7 @@ my $opt_verbose;
 my $opt_quiet;
 my $opt_noask;
 my $opt_help;
-my $opt_nodhcp;
+our $opt_nodhcp;
 
 Getopt::Long::Configure ("bundling", "passthrough");
 

--- a/provision/lib/Warewulf/Event/Dhcp.pm
+++ b/provision/lib/Warewulf/Event/Dhcp.pm
@@ -23,9 +23,9 @@ my $event = Warewulf::EventHandler->new();
 sub
 update_dhcp()
 {
-    if ($opt_nodhcp) {
+    if ($main::opt_nodhcp) {
         &wprint("Skipping DHCP update. Manually run: wwsh dhcp update\n");
-        return 1;
+        return &ret_sucess();
     }
 
     my $dhcp = Warewulf::Provision::DhcpFactory->new();


### PR DESCRIPTION
The `$opt_nodhcp` variable wasn't being carried down to the objects. Force a global variable at the `wwsh` level, and check that with `$main::opt_nodhcp`.

Use the correct thing for returning a value as well.

Thanks @bensallen for testing! ;)