### PR TITLE
Issue #78 Impementation - auto-sync gid/uid/mode metadata

### DIFF
--- a/common/lib/Warewulf/File.pm
+++ b/common/lib/Warewulf/File.pm
@@ -427,7 +427,6 @@ sync()
         if ( $was_stored ) {
             $self->checksum($digest->hexdigest());
             $self->size($total_len);
-            $db->persist($self);
             if ( $metadata ) {
                 if( @statinfo && ( scalar($self->origin())  == 1 ) ) {
                     $self->gid( $statinfo[5] );
@@ -437,6 +436,7 @@ sync()
                     &dprint("Skipping auto-syncing of file object $name. The path doesn't exist or there are multiple origins.\n" );
                 }
             } 
+            $db->persist($self);
         } else {
             &eprint("Failure:  only wrote $cur_len of $total_len bytes to binstore\n");
         }

--- a/common/lib/Warewulf/File.pm
+++ b/common/lib/Warewulf/File.pm
@@ -339,7 +339,7 @@ origin()
 }
 
 
-=item sync()
+=item sync($metadata)
 
 Resync any file objects to their origin on the local file system. This will
 persist immediately to the DataStore.
@@ -351,7 +351,7 @@ Note: This will also update some metadata for this file.
 sub
 sync()
 {
-    my ($self) = @_;
+    my ($self, $metadata) = @_;
     my $name = $self->name();
     my ($event, $event_name);
 
@@ -360,6 +360,7 @@ sync()
         my $binstore = $db->binstore($self->id());
         my ($total_len, $cur_len, $start, $data) = (0, 0, 0, "");
         my $digest;
+        my @statinfo;
 
         &dprint("Syncing file object: $name\n");
         foreach my $origin ($self->origin()) {
@@ -427,6 +428,15 @@ sync()
             $self->checksum($digest->hexdigest());
             $self->size($total_len);
             $db->persist($self);
+            if ( $metadata ) {
+                if( @statinfo && ( scalar($self->origin())  == 1 ) ) {
+                    $self->gid( $statinfo[5] );
+                    $self->uid( $statinfo[4] );
+                    $self->mode( S_IMODE($statinfo[2]) );
+                } else {
+                    &dprint("Skipping auto-syncing of file object $name. The path doesn't exist or there are multiple origins.\n" );
+                }
+            } 
         } else {
             &eprint("Failure:  only wrote $cur_len of $total_len bytes to binstore\n");
         }

--- a/common/lib/Warewulf/Module/Cli/File.pm
+++ b/common/lib/Warewulf/Module/Cli/File.pm
@@ -83,6 +83,7 @@ help()
     $h .= "     -g, --gid          Set the GID for this file\n";
     $h .= "     -n, --name         Set the reference name for this file (not path!)\n";
     $h .= "         --interpreter  Set the interpreter name to parse this file\n";
+    $h .= "         --overwrite    Overwrite the metadata in the file object on sync() to match the file at the origin path\n";
     $h .= "\n";
     $h .= "NOTE:  Use \"UNDEF\" to erase the current contents of a given field.\n";
     $h .= "\n";
@@ -180,6 +181,7 @@ exec()
     my $opt_gid;
     my $opt_interpreter;
     my @opt_origin;
+    my $opt_overwrite;
 
     @ARGV = ();
     push(@ARGV, @_);
@@ -198,6 +200,7 @@ exec()
         'u|uid=s'       => \$opt_uid,
         'g|gid=s'       => \$opt_gid,
         'interpreter=s' => \$opt_interpreter,
+        'overwrite'     => \$opt_overwrite,
     );
     if (! $opt_program) {
         if (exists($ENV{"EDITOR"})) {
@@ -481,7 +484,7 @@ exec()
                 if (scalar(@ARGV) && ($orig eq "UNDEF") && ($obj->name() ne "dynamic_hosts")) {
                     &nprintf("%-16s :: No ORIGIN defined\n", $obj->name());
                 }
-                $obj->sync();
+                $obj->sync($opt_overwrite);
             }
         } elsif ($command eq "list" or $command eq "ls") {
             #&nprint("NAME               FORMAT       SIZE(K)  FILE PATH\n");


### PR DESCRIPTION
Adds new `--overwrite` flag on the file object in `wwsh`.  This flag allows the file object to automatically use the file's metadata for updating the gid / uid / mode on the file object.  

**Hi everyone!  This is my first pull request on this project.  I'm pretty new to Perl in general, as well as Warewulf3, so I'm very open to feedback.  I hope this helps.**
