### PR TITLE
Add message about VNFS /sbin/init verification failure

### DIFF
--- a/provision/initramfs/capabilities/transport-http/wwgetvnfs
+++ b/provision/initramfs/capabilities/transport-http/wwgetvnfs
@@ -88,6 +88,9 @@ while true; do
 
         if [ -x "$NEWROOT/sbin/init" ] || [ -h "$NEWROOT/sbin/init" ]; then
             exit 0
+        else
+            msg_gray "      * $NEWROOT/sbin/init could not be verified. Retrying."
+            wwlogger "$NEWROOT/sbin/init could not be verified. Retrying VNFS download."
         fi
 
     done


### PR DESCRIPTION
When the check in `wwgetvnfs` for `$NEWROOT/sbin/init` fails, print out a message about looping.