### PR TITLE
wwinit: Check if service is enabled before enabling it

### DIFF
--- a/common/etc/functions
+++ b/common/etc/functions
@@ -239,7 +239,8 @@ wwservice_activate() {
             fi
             if systemctl list-unit-files --type=service,socket | egrep -q "^$SERVICE"; then
                 wwprint "Activating Systemd unit: $1\n"
-                if wwrun /bin/systemctl -q enable $SERVICE; then
+                if systemctl is-enabled --quiet $SERVICE ||
+			wwrun /bin/systemctl -q enable $SERVICE; then
                     if wwrun /bin/systemctl -q restart $SERVICE; then
                         return 0
                     fi


### PR DESCRIPTION
This avoids ugly error messages.

Signed-off-by: Egbert Eich <eich@suse.com>