### PR TITLE
Suse prov dhcpd add vendor class identifier

### DIFF
--- a/provision/etc/dhcpd-template.conf
+++ b/provision/etc/dhcpd-template.conf
@@ -12,6 +12,9 @@ option ipxe.no-pxedhcp 1;
 option architecture-type   code 93  = unsigned integer 16;
 
 if exists user-class and option user-class = "iPXE" {
+    if exists vendor-class-identifier {
+         option vendor-class-identifier = option vendor-class-identifier;
+    }
     filename "http://%{IPADDR}/WW/ipxe/cfg/${mac}";
 } else {
     if option architecture-type = 00:0B {


### PR DESCRIPTION
    Add DHPC vendor-class-identifier option for iPXE
    
    With multiple DHCP server present, iPXE may chose the wrong one
    if no option vendor-class-identifier is present in DHCP offer.
    
    Signed-off-by: Egbert Eich <eich@suse.com>