### PR TITLE
common: Correctly detect SUSE system for system services

### DIFF
--- a/common/lib/Warewulf/SystemFactory.pm
+++ b/common/lib/Warewulf/SystemFactory.pm
@@ -47,13 +47,24 @@ new($$)
     my ($mod_name, $obj);
 
     if (! $type) {
+        $type = "unsupported";
         if (-f "/etc/redhat-release") {
             $type = "rhel";
         } elsif (-f "/etc/SuSE-release") {
             $type = "Suse";
-        }
-		else {
+        } elsif ( -f "/etc/debian_version" ) {
             $type = "Deb";
+        } elsif ( -f "/etc/os-release") {
+            open(SYSTEM, "/etc/os-release");
+            while (<SYSTEM>) {
+                if (/^NAME=/) {
+                    if (/SUSE|SLE/) {
+                        $type = "Suse";
+                    }
+                    last;
+                }
+            }
+            close SYSTEM;
         }
     }
 


### PR DESCRIPTION
Since /etc/SuSE-release was removed the detection of SUSE systems for systemd services didn't
work correctly any more. It was replaced by /etc/os-release.

Signed-off-by: Egbert Eich <eich@suse.com>