### PR TITLE
Remove shebang from scripts only intended to be sourced

### DIFF
--- a/cluster/etc/cluster-env.csh
+++ b/cluster/etc/cluster-env.csh
@@ -1,5 +1,3 @@
-#!/bin/tcsh
-
 if ( -x "/usr/bin/cluster-env" ) then
    /usr/bin/cluster-env
 endif

--- a/cluster/etc/cluster-env.sh
+++ b/cluster/etc/cluster-env.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 if [ -x "/usr/bin/cluster-env" ]; then
    /usr/bin/cluster-env
 fi

--- a/vnfs/libexec/wwmkchroot/functions
+++ b/vnfs/libexec/wwmkchroot/functions
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 eval `wwconfig -as`
 
 MEDIA_MOUNTPATH="$CHROOTDIR/tmp/wwmkchroot.mount"


### PR DESCRIPTION
When a shell script is not intended to be executed as a stand-alone
executable, the shebang at the start of the script is not necessary. In
cases where the script should not be executed, the shebang should be
removed. The following scripts are specifically sourced by other
executable scripts and thus have no need for the shebang:

    cluster/etc/cluster-env.csh
    cluster/etc/cluster-env.sh
    vnfs/libexec/wwmkchroot/functions

Signed-off-by: John L. Jolly <jjolly@suse.com>