### PR TITLE
Cleanup for changes in #130.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ provision/3rd_party/pxelinux.0
 provision/3rd_party/syslinux32.efi
 provision/3rd_party/syslinux64.efi
 provision/initramfs/_work/
+provision/initramfs/busybox.config
 provision/initramfs/capabilities/*/capability.cpio
 provision/initramfs/capabilities/*/rootfs/
 provision/initramfs/initramfs.cpio


### PR DESCRIPTION
busybox.config is now generated with autoconfig after #130 so add it to gitignore.