### PR TITLE
Skip copying kernel modules from initrd to newroot if NOKMODCOPY is set

### DIFF
--- a/provision/initramfs/capabilities/provision-vnfs/70-kernelmodules
+++ b/provision/initramfs/capabilities/provision-vnfs/70-kernelmodules
@@ -7,6 +7,9 @@
 # required approvals from the U.S. Dept. of Energy).  All rights reserved.
 #
 
+if [ -n "${WWNOKMODCOPY}" ]; then
+    exit 0
+fi
 
 KVERSION=$(uname -r)
 


### PR DESCRIPTION
Skip copying kernel modules from initrd to newroot if NOKMODCOPY is set. 

Useful in a specific case with Mellanox OFED:

1. Including the Mellanox drivers into the bootstrap
2. Booting over IB or booting over a Mellanox ethernet adapter and then later bringing up IB interfaces 
3. Making use of weak-modules, so you don't have to rebuild the Mellanox OFED kernel modules for each kernel patch release.

Currently wwbootstrap readlink's any symlink found. weak-modules symlinks back to the built-for kernel install of the module. It then copies the destination instead of the symbolic link itself into the bootstrap CPIO. This is useful as weak-modules are thus grabbed and supported within the initrd.

However 70-kernelmodules copies all the initrd's kernel modules into newroot during boot. In this case, it copies the given weak-module kernel modules over the top of the symlinks in newroot. This typically isn't a big deal, but Mellanox OFED's init script, openibd, checks if the kernel module is part of one of its RPMs. Since we copy the kernel module and not its symlink, at this point that kernel module is not part of an RPM, and openibd fails to bring up the IB interfaces. 

There's numerous kludgy things wrong with this, but simply not copying the kernel modules is the easiest fix. 

We could also look at having wwbootstrap preserve the weak-module symlink and the original location of the kernel module. Assuming busybox will support this...