### PR TITLE
Try to set UID_MIN dynamically based on login.defs.

### DIFF
--- a/cluster/bin/cluster-env
+++ b/cluster/bin/cluster-env
@@ -9,7 +9,12 @@
 
 _UID=`id -u`
 
-if [ $_UID -lt 500 -a $_UID -ne 0 ]; then
+_UID_MIN=`grep '^UID_MIN' /etc/login.defs 2>/dev/null | tail -n 1 | awk '{print $2;}'`
+if [ -z "$_UID_MIN" ]; then
+    _UID_MIN=500
+fi
+
+if [ $_UID -lt "$_UID_MIN" -a $_UID -ne 0 ]; then
     exit
 fi
 


### PR DESCRIPTION
CentOS 7.5, and other recent distributions of GNU/Linux, now use 1000 as the default minimum UID. Furthermore, administrators are free to choose their own ID spaces. As such, cluster-env can incorrectly setup SSH keys for system users. This patch will attempt to discern UID_MIN from /etc/login.defs and use 500 as a default if it fails.