### PR TITLE
Remove bogus "  * checksum ..." from transport-http/wwgetvnfs

### DIFF
--- a/provision/initramfs/capabilities/transport-http/wwgetvnfs
+++ b/provision/initramfs/capabilities/transport-http/wwgetvnfs
@@ -73,7 +73,6 @@ while true; do
         fi
 
         msg_gray "   * checksum ${WWVNFS_CHECKSUM:-}"
-         "   * checksum ${WWVNFS_CHECKSUM:-}"
         if [ "${VALIDATE_VNFS}" -eq 1 ]; then
             CHECKSUM=$(cut -f1 -d " " /tmp/wwgetvnfs_checksum)
             if [ "${CHECKSUM}" != "${WWVNFS_CHECKSUM:-}" ]; then


### PR DESCRIPTION
This was causing an error in /var/log/warewulf/provision/getvnfs.log and appears to simply be the output of the previous msg_gray mistakenly inserted into the script. Was being executed on the command line as: "* checksum <checksum value>"