### PR TITLE
Add missing parameters present in "wwsh provision set" to "wwsh provision print"

### DIFF
--- a/provision/lib/Warewulf/Module/Cli/Provision.pm
+++ b/provision/lib/Warewulf/Module/Cli/Provision.pm
@@ -787,11 +787,15 @@ exec()
             }
 
             &nprintf("#### %s %s#\n", $name, "#" x (72 - length($name)));
+            printf("%15s: %-16s = %s\n", $name, "MASTER", join(",", $o->master()) || "UNDEF");
             printf("%15s: %-16s = %s\n", $name, "BOOTSTRAP", $bootstrap);
             printf("%15s: %-16s = %s\n", $name, "VNFS", $vnfs);
+            printf("%15s: %-16s = %s\n", $name, "VALIDATE", $o->validate_vnfs() ? "TRUE" : "FALSE");
             printf("%15s: %-16s = %s\n", $name, "FILES", join(",", @files));
             printf("%15s: %-16s = %s\n", $name, "PRESHELL", $o->preshell() ? "TRUE" : "FALSE");
             printf("%15s: %-16s = %s\n", $name, "POSTSHELL", $o->postshell() ? "TRUE" : "FALSE");
+            printf("%15s: %-16s = %s\n", $name, "POSTNETDOWN", $o->postnetdown() ? "TRUE" : "FALSE");
+            printf("%15s: %-16s = %s\n", $name, "POSTREBOOT", $o->postreboot() ? "TRUE" : "FALSE");
             printf("%15s: %-16s = %s\n", $name, "CONSOLE", $o->console() || "UNDEF");
             printf("%15s: %-16s = %s\n", $name, "PXELOADER", $o->pxeloader() || "UNDEF");
             printf("%15s: %-16s = %s\n", $name, "IPXEURL", $o->ipxeurl() || "UNDEF");


### PR DESCRIPTION
While it was possible to do `wwsh provision set` `--master`, `--validate`, `--postnetdown`, and `--postreboot`, it was not possible to see them without using `wwsh object`. I think that's likely not the best/intended behavior, and makes those things a trap for you once you've set them. This patch adds everything to `wwsh provision print` that's settable via `wwsh provision set`.

There's also a second commit that's a merge in this one apparently because of the way I did the last patch and then subsequently merged it to my development branch. I don't think it has any substantive impact. Sorry about the clutter (new at this).