### PR TITLE
Add in missing logic for setting VNFS name in `wwsh vnfs set`

### DIFF
--- a/provision/lib/Warewulf/Module/Cli/Provision.pm
+++ b/provision/lib/Warewulf/Module/Cli/Provision.pm
@@ -787,11 +787,15 @@ exec()
             }
 
             &nprintf("#### %s %s#\n", $name, "#" x (72 - length($name)));
+            printf("%15s: %-16s = %s\n", $name, "MASTER", join(",", $o->master()) || "UNDEF");
             printf("%15s: %-16s = %s\n", $name, "BOOTSTRAP", $bootstrap);
             printf("%15s: %-16s = %s\n", $name, "VNFS", $vnfs);
+            printf("%15s: %-16s = %s\n", $name, "VALIDATE", $o->validate_vnfs() ? "TRUE" : "FALSE");
             printf("%15s: %-16s = %s\n", $name, "FILES", join(",", @files));
             printf("%15s: %-16s = %s\n", $name, "PRESHELL", $o->preshell() ? "TRUE" : "FALSE");
             printf("%15s: %-16s = %s\n", $name, "POSTSHELL", $o->postshell() ? "TRUE" : "FALSE");
+            printf("%15s: %-16s = %s\n", $name, "POSTNETDOWN", $o->postnetdown() ? "TRUE" : "FALSE");
+            printf("%15s: %-16s = %s\n", $name, "POSTREBOOT", $o->postreboot() ? "TRUE" : "FALSE");
             printf("%15s: %-16s = %s\n", $name, "CONSOLE", $o->console() || "UNDEF");
             printf("%15s: %-16s = %s\n", $name, "PXELOADER", $o->pxeloader() || "UNDEF");
             printf("%15s: %-16s = %s\n", $name, "IPXEURL", $o->ipxeurl() || "UNDEF");

--- a/provision/lib/Warewulf/Module/Cli/Vnfs.pm
+++ b/provision/lib/Warewulf/Module/Cli/Vnfs.pm
@@ -319,6 +319,14 @@ exec()
                 return undef;
             }
 
+            if ($opt_name) {
+               foreach my $o ($objSet->get_list()) {
+                    $o->name($opt_name);
+                    $persist_count++;
+                }
+                push(@changes, sprintf("%8s: %-20s = %s\n", "SET", "NAME", $opt_name));
+            }  
+
             if ($opt_chroot) {
                 if ($opt_chroot =~ /^([a-zA-Z0-9\/\.\-_]+)$/) {
                     if (-d $opt_chroot) {
@@ -340,7 +348,6 @@ exec()
                     $persist_count++;
                 }
                 push(@changes, sprintf("%8s: %-20s = %s\n", "SET", "ARCH", $opt_arch));
-
             }
 
             if ($persist_count > 0) {


### PR DESCRIPTION
Using the $opt_arch section as a guide, I added in the ability to do `wwsh vnfs set <vnfs_name> -n <new_name>` -- previously, such a command was ignored, counter to what the help output of `wwsh vnfs` would appear to suggest. Looking in the source code, it apparently only ever had an effect in `wwsh import` mode. Tested this and it seems to work as expected.