### PR TITLE
Support stateful provisioning to NVME devices

### DIFF
--- a/provision/etc/filesystem/examples/Makefile.am
+++ b/provision/etc/filesystem/examples/Makefile.am
@@ -1,6 +1,6 @@
 confdir = $(sysconfdir)/warewulf/filesystem/examples
 
-dist_conf_DATA = efi_example.cmds gpt_example.cmds gpt_label_example.cmds gpt_uuid_example.cmds hybrid_example.cmds mbr_example.cmds tmpfs_example.cmds
+dist_conf_DATA = efi_example.cmds efi_nvme_example.cmds gpt_example.cmds gpt_label_example.cmds gpt_uuid_example.cmds hybrid_example.cmds mbr_example.cmds tmpfs_example.cmds
 
 MAINTAINERCLEANFILES = Makefile.in
 

--- a/provision/etc/filesystem/examples/efi_nvme_example.cmds
+++ b/provision/etc/filesystem/examples/efi_nvme_example.cmds
@@ -1,0 +1,26 @@
+# EFI / GPT Example for NVME device
+
+# Note that partitions on NVME drives are named by appending "pN" to
+# the device name, where N is the partition index, and not just the
+# partition index.
+
+# Parted specific commands
+select /dev/nvme0n1
+mklabel gpt
+mkpart ESP fat32 1MiB 513MiB
+mkpart primary linux-swap 513MiB 1025MiB
+mkpart primary ext4 1025MiB 100%
+name 1 ESP
+name 2 swap
+name 3 root
+set 1 boot on
+
+# mkfs NUMBER FS-TYPE [ARGS...]
+mkfs p1 vfat -n ESP
+mkfs p2 swap
+mkfs p3 ext4 -L root
+
+# fstab NUMBER fs_file fs_vfstype fs_mntops fs_freq fs_passno
+fstab p3 / ext4 defaults 0 0
+fstab p1 /boot/efi vfat defaults 0 0
+fstab p2 swap swap defaults 0

--- a/vnfs/etc/bootstrap.conf
+++ b/vnfs/etc/bootstrap.conf
@@ -5,6 +5,7 @@
 drivers += kernel/drivers/net/, kernel/drivers/scsi/, kernel/drivers/ata/
 drivers += kernel/drivers/virtio/, kernel/drivers/message/, kernel/drivers/md/
 drivers += kernel/drivers/block/, kernel/drivers/usb/host/, kernel/drivers/firmware/efi/
+drivers += kernel/drivers/nvme/host/
 drivers += nfs, nfsd, nfs_common, nfsv4
 drivers += fuse, ext2, ext3, ext4
 drivers += fat, vfat, nls_cp437, nls_ascii, efivarfs


### PR DESCRIPTION
In order to do stateful provisioning to NVME devices, the NVME host
drivers need to be added to the bootstrap image. Also, as partitions
on NVME devices are named by appending 'pN' to the device name, add an
example filesystem config demonstrating how to do this.

Signed-off-by: Janne Blomqvist <janne.blomqvist@aalto.fi>