### PR TITLE
Manually configure master IP/network/netmask

### DIFF
--- a/provision/etc/provision.conf
+++ b/provision/etc/provision.conf
@@ -3,6 +3,13 @@
 # communicate with the nodes?
 network device = eth1
 
+# Alternatively configure the network addresses directly, e.g. if the
+# network device name might change. This overrides the values derived 
+# from the 'network device' setting (if configured) one by one.
+# ip address = 172.16.1.1
+# ip netmask = 255.255.0.0
+# ip network = 172.16.0.0 
+
 # Which DHCP server implementation should be used?
 dhcp server = isc
 

--- a/provision/lib/Warewulf/Provision/Dhcp/Isc.pm
+++ b/provision/lib/Warewulf/Provision/Dhcp/Isc.pm
@@ -168,7 +168,7 @@ persist()
 
 
     if (! $ipaddr or ! $netmask or ! $network) {
-        &wprint("Could not configure DHCP, check 'network device' configuration!\n");
+        &wprint("Could not configure DHCP, check 'network device' or 'ip address/netmask/network' configuration!\n");
         return undef;
     }
 

--- a/provision/lib/Warewulf/Provision/Dhcp/Isc.pm
+++ b/provision/lib/Warewulf/Provision/Dhcp/Isc.pm
@@ -149,9 +149,9 @@ persist()
     my $netobj = Warewulf::Network->new();
     my $config = Warewulf::Config->new("provision.conf");
     my $devname = $config->get("network device");
-    my $ipaddr = $netobj->ipaddr($devname);
-    my $netmask = $netobj->netmask($devname);
-    my $network = $netobj->network($devname);
+    my $ipaddr = $config->get("ip address") // $netobj->ipaddr($devname);
+    my $netmask = $config->get("ip netmask") // $netobj->netmask($devname);
+    my $network = $config->get("ip network") // $netobj->network($devname);
     my $config_template;
     my $dhcpd_contents;
     my %seen;

--- a/provision/lib/Warewulf/Provision/HostsFile.pm
+++ b/provision/lib/Warewulf/Provision/HostsFile.pm
@@ -93,9 +93,9 @@ generate()
 
     my $netdev = $config->get("network device");
     my $defdomain = $config->get("use localdomain") || "yes";
-    my $master_ipaddr = $netobj->ipaddr($netdev);
-    my $master_netmask = $netobj->netmask($netdev);
-    my $master_network = $netobj->network($netdev);
+    my $master_ipaddr = $config->get("ip address") // $netobj->ipaddr($netdev);
+    my $master_network = $config->get("ip network") // $netobj->network($netdev);
+    my $master_netmask = $config->get("ip netmask") // $netobj->netmask($netdev);
 
     if (! $master_ipaddr or ! $master_netmask or ! $master_network) {
         &wprint("Could not generate hostfile, check 'network device' configuration!\n");

--- a/provision/lib/Warewulf/Provision/HostsFile.pm
+++ b/provision/lib/Warewulf/Provision/HostsFile.pm
@@ -98,7 +98,7 @@ generate()
     my $master_netmask = $config->get("ip netmask") // $netobj->netmask($netdev);
 
     if (! $master_ipaddr or ! $master_netmask or ! $master_network) {
-        &wprint("Could not generate hostfile, check 'network device' configuration!\n");
+        &wprint("Could not generate hostfile, check 'network device' or 'ip address/netmask/network' configuration!\n");
         return undef;
     }
 

--- a/provision/lib/Warewulf/Provision/Pxe.pm
+++ b/provision/lib/Warewulf/Provision/Pxe.pm
@@ -136,9 +136,9 @@ update()
     my $db = Warewulf::DataStore->new();
     my $config = Warewulf::Config->new("provision.conf");
     my $devname = $config->get("network device");
-    my $master_ipaddr = $netobj->ipaddr($devname);
-    my $master_network = $netobj->network($devname);
-    my $master_netmask = $netobj->netmask($devname);
+    my $master_ipaddr = $config->get("ip address") // $netobj->ipaddr($devname);
+    my $master_network = $config->get("ip network") // $netobj->network($devname);
+    my $master_netmask = $config->get("ip netmask") // $netobj->netmask($devname);
 
     if (! $master_ipaddr) {
         &wprint("Could not generate PXE configurations, check 'network device' configuration!\n");

--- a/provision/lib/Warewulf/Provision/Pxe.pm
+++ b/provision/lib/Warewulf/Provision/Pxe.pm
@@ -141,7 +141,7 @@ update()
     my $master_netmask = $config->get("ip netmask") // $netobj->netmask($devname);
 
     if (! $master_ipaddr) {
-        &wprint("Could not generate PXE configurations, check 'network device' configuration!\n");
+        &wprint("Could not generate PXE configurations, check 'network device' or 'ip address/netmask/network' configuration!\n");
         return undef;
     }
 


### PR DESCRIPTION
Allow direct configuration of IP/network/netmask for DHCP/PXE in provision.conf.

This is useful for systems where we have no control over the naming of network interfaces and a DHCP server running on the wrong interface might have unpleasant side effects.

Settings are completely optional; if not set, addresses are derived from 'network device' setting as before.