### PR TITLE
Fix: renamed pxelinux attribute

### DIFF
--- a/common/share/wwsh.1
+++ b/common/share/wwsh.1
@@ -759,7 +759,7 @@ Set a specific console for the kernel command line.
 Define the kernel arguments (assumes "net.ifnames=0 biosdevname=0 quiet" if UNDEF).
 .RE
 .PP
-.B \-\-pxelinux    
+.B \-\-pxeloader    
 .RS 4
 Define a custom PXELINUX/boot image to use.
 .RE

--- a/provision/lib/Warewulf/Provision/Dhcp/Dnsmasq.pm
+++ b/provision/lib/Warewulf/Provision/Dhcp/Dnsmasq.pm
@@ -209,7 +209,6 @@ persist()
         if (! @bootservers or scalar(grep { $_ eq $ipaddr} @bootservers)) {
             my $clustername = $n->cluster();
             my $domainname = $n->domain();
-            my $pxelinux_file = $n->pxelinux();
             my $master_ipv4_addr;
             my $domain;
 


### PR DESCRIPTION
pxelinux was renamed to pxeloader

The Dnsmasq module still used the old method - a copy&paste artifact from Isc module in master. Dnsmasq does not support overriding the pxe boot image per node, so I removed the unnecessary call.

Also the wwsh manpage did not reflect the changed parameter name.