### PR TITLE
Add OpenSUSE 15 support

### DIFF
--- a/cluster/libexec/wwinit/50-tftp.init
+++ b/cluster/libexec/wwinit/50-tftp.init
@@ -23,7 +23,7 @@ wwreqroot
 DHCP="$(egrep "^\s*dhcp server\s*=" $WAREWULF_SYSCONFDIR/warewulf/provision.conf | awk -F = '{print $2}' | sed -e 's/\s*//g' | tr '[:upper:]' '[:lower:]')"
 
 if [ "$DHCP" = "isc" ]; then
-    if wwpackage_check tftp-server tftpd tftpd-hpa; then
+    if wwpackage_check tftp-server tftpd tftpd-hpa tftp\(server\); then
         if wwservice_activate tftp.socket tftpd tftp tftpd-hpa; then
             exit 0
         fi

--- a/common/lib/Warewulf/System/Suse.pm
+++ b/common/lib/Warewulf/System/Suse.pm
@@ -80,7 +80,9 @@ service($$$)
         while(<SERVICE>) {
             $self->{"OUTPUT"} .= $_;
         }
-        chomp($self->{"OUTPUT"});
+        if (defined($self->{"OUTPUT"})) {
+            chomp($self->{"OUTPUT"});
+        }
         if (close SERVICE) {
             &dprint("Service command ran successfully\n");
             return(1);

--- a/platform/build-OpenSUSE-15.sh
+++ b/platform/build-OpenSUSE-15.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+zypper install autoconf automake libacl-devel libattr-devel libuuid-devel nfs-kernel-server device-mapper-devel xz-devel apache2 apache2-mod_perl tftp dhcp-server xinetd tcpdump policycoreutils-python sles-release util-linux mysql perl-DBD-mysql openssl-devel wget gcc ipmitool ipxe
+
+if [ $? -eq 0 ]; then
+    for SUBDIR in common cluster vnfs ipmi provision; do
+        cd ../$SUBDIR
+        if [ $? -ne 0 ]; then
+            break
+        fi
+        if [ "$SUBDIR" = "ipmi" ]; then
+          ./autogen.sh --with-local-ipmitool --prefix=/
+        else
+          ./autogen.sh --prefix=/
+        fi
+        if [ $? -eq 0 ]; then
+            make
+        else
+            echo "$SUBDIR: autogen failed"
+            break
+        fi
+        if [ $? -eq 0 ]; then
+            make install
+        else
+            echo "$SUBDIR: make failed"
+            break
+        fi
+        if [ $? -ne 0 ]; then
+            echo "$SUBDIR: make install failed"
+            break
+        fi
+    done
+fi
+

--- a/platform/build-OpenSUSE-15.sh
+++ b/platform/build-OpenSUSE-15.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-zypper install autoconf automake libacl-devel libattr-devel libuuid-devel nfs-kernel-server device-mapper-devel xz-devel apache2 apache2-mod_perl tftp dhcp-server xinetd tcpdump policycoreutils-python sles-release util-linux mysql perl-DBD-mysql openssl-devel wget gcc ipmitool ipxe
+zypper install autoconf automake libacl-devel libattr-devel libuuid-devel nfs-kernel-server device-mapper-devel xz-devel apache2 apache2-mod_perl tftp dhcp-server xinetd tcpdump python3-policycoreutils util-linux mariadb perl-DBD-mysql libopenssl-devel wget gcc ipmitool ipxe-bootimgs python3 make libtirpc-devel parted autofs bzip2 ntp perl-CGI
 
 if [ $? -eq 0 ]; then
     for SUBDIR in common cluster vnfs ipmi provision; do
@@ -10,6 +10,8 @@ if [ $? -eq 0 ]; then
         fi
         if [ "$SUBDIR" = "ipmi" ]; then
           ./autogen.sh --with-local-ipmitool --prefix=/
+        elif [ "$SUBDIR" = "provision" ]; then
+	  ./autogen.sh --with-apache2moddir=/usr/lib64/apache2 --prefix=/
         else
           ./autogen.sh --prefix=/
         fi

--- a/platform/build-OpenSUSE-15.sh
+++ b/platform/build-OpenSUSE-15.sh
@@ -4,17 +4,18 @@ zypper install autoconf automake libacl-devel libattr-devel libuuid-devel nfs-ke
 
 if [ $? -eq 0 ]; then
     for SUBDIR in common cluster vnfs ipmi provision; do
+        OPTIONS=" "
         cd ../$SUBDIR
         if [ $? -ne 0 ]; then
             break
         fi
-        if [ "$SUBDIR" = "ipmi" ]; then
-          ./autogen.sh --with-local-ipmitool --prefix=/
-        elif [ "$SUBDIR" = "provision" ]; then
-	  ./autogen.sh --with-apache2moddir=/usr/lib64/apache2 --prefix=/
-        else
-          ./autogen.sh --prefix=/
+        if [ "$SUBDIR" = "provision" ]; then
+	  OPTIONS="--with-apache2moddir=/usr/lib64/apache2"
         fi
+	if [ "$SUBDIR" = "ipmi" ]; then
+          OPTIONS="--with-local-ipmitool"
+        fi
+          ./autogen.sh --prefix=/ --bindir=/usr/bin $OPTIONS
         if [ $? -eq 0 ]; then
             make
         else

--- a/platform/build-Ubuntu-18.sh
+++ b/platform/build-Ubuntu-18.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-apt install apache2 libapache2-mod-perl2 tftpd-hpa mysql-server debootstrap isc-dhcp-server tcpdump openssh-client nfs-kernel-server nfs-common rpcbind ntp wget build-essential perl make automake pkg-config libarchive-tools ipxe libtirpc-dev libselinux-dev gcc python python3 libssl-dev uuid-dev libblkid-dev gettext libdevmapper-dev liblzma-dev ipmitool 
+apt install apache2 libapache2-mod-perl2 tftpd-hpa mysql-server debootstrap isc-dhcp-server tcpdump openssh-client nfs-kernel-server nfs-common rpcbind ntp wget build-essential perl make automake pkg-config libarchive-tools ipxe libtirpc-dev libselinux-dev gcc python python3 libssl-dev uuid-dev libblkid-dev gettext libdevmapper-dev liblzma-dev ipmitool libdbi-perl libdbd-mysql-perl
 
 if [ $? -eq 0 ]; then
     for SUBDIR in common cluster vnfs ipmi provision; do
@@ -14,15 +14,9 @@ if [ $? -eq 0 ]; then
         fi
           ./autogen.sh --prefix=/ --bindir=/usr/bin $OPTIONS
         if [ $? -eq 0 ]; then
-            make
-        else
-            echo "$SUBDIR: autogen failed"
-            break
-        fi
-        if [ $? -eq 0 ]; then
             make install
         else
-            echo "$SUBDIR: make failed"
+            echo "$SUBDIR: autogen failed"
             break
         fi
         if [ $? -ne 0 ]; then

--- a/platform/build-Ubuntu-18.sh
+++ b/platform/build-Ubuntu-18.sh
@@ -4,15 +4,15 @@ apt install apache2 libapache2-mod-perl2 tftpd-hpa mysql-server debootstrap isc-
 
 if [ $? -eq 0 ]; then
     for SUBDIR in common cluster vnfs ipmi provision; do
+        OPTIONS=" "
         cd ../$SUBDIR
         if [ $? -ne 0 ]; then
             break
         fi
         if [ "$SUBDIR" = "ipmi" ]; then
-          ./autogen.sh --with-local-ipmitool --prefix=/
-        else
-          ./autogen.sh --prefix=/
+          OPTIONS="--with-local-ipmitool"
         fi
+          ./autogen.sh --prefix=/ --bindir=/usr/bin $OPTIONS
         if [ $? -eq 0 ]; then
             make
         else

--- a/platform/build-Ubuntu-18.sh
+++ b/platform/build-Ubuntu-18.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-apt install apache2 libapache2-mod-perl2 tftpd-hpa mysql-server debootstrap isc-dhcp-server tcpdump openssh-client nfs-kernel-server nfs-common rpcbind ntp wget build-essential perl make automake pkg-config busybox e2fsprogs parted libarchive-tools ipxe libtirpc-dev libselinux-dev gcc python python3 libssl-dev uuid-dev libblkid-dev gettext libdevmapper-dev liblzma-dev ipmitool 
+apt install apache2 libapache2-mod-perl2 tftpd-hpa mysql-server debootstrap isc-dhcp-server tcpdump openssh-client nfs-kernel-server nfs-common rpcbind ntp wget build-essential perl make automake pkg-config libarchive-tools ipxe libtirpc-dev libselinux-dev gcc python python3 libssl-dev uuid-dev libblkid-dev gettext libdevmapper-dev liblzma-dev ipmitool 
 
 if [ $? -eq 0 ]; then
     for SUBDIR in common cluster vnfs ipmi provision; do

--- a/provision/configure.ac
+++ b/provision/configure.ac
@@ -41,6 +41,14 @@ AM_COND_IF([ISDEB],
     AC_MSG_RESULT([no])
 )
 
+AC_MSG_CHECKING([for Ubuntu based system])
+AM_CONDITIONAL(ISUBU, [test -e /etc/lsb-release &&
+		       grep -q "DISTRIB_ID=\".*buntu.*\"" /etc/lsb-release])
+AM_COND_IF([ISUBU],
+    AC_MSG_RESULT([yes]),
+    AC_MSG_RESULT([no])
+)
+
 AC_MSG_CHECKING([for SUSE based system])
 AM_CONDITIONAL(ISSUSE, [test -e /etc/SUSEConfig ||
 		       { test -e /etc/os-release &&

--- a/provision/configure.ac
+++ b/provision/configure.ac
@@ -43,7 +43,7 @@ AM_COND_IF([ISDEB],
 
 AC_MSG_CHECKING([for Ubuntu based system])
 AM_CONDITIONAL(ISUBU, [test -e /etc/lsb-release &&
-		       grep -q "DISTRIB_ID=\".*buntu.*\"" /etc/lsb-release])
+		       grep -q "DISTRIB_ID=.*buntu.*" /etc/lsb-release])
 AM_COND_IF([ISUBU],
     AC_MSG_RESULT([yes]),
     AC_MSG_RESULT([no])

--- a/provision/etc/Makefile.am
+++ b/provision/etc/Makefile.am
@@ -3,21 +3,23 @@ SUBDIRS = defaults filesystem
 confdir = $(sysconfdir)/warewulf/
 bash_completiondir = $(sysconfdir)/bash_completion.d/
 
-# Check for Debian
-if ISDEB
-httpdir = $(sysconfdir)/apache2/conf.d/
-endif
-# Check for SUSE
-if ISSUSE
-httpdir = $(sysconfdir)/apache2/conf.d/
-endif
-# Check for Ubuntu
+# Check for Ubuntu first, then for Debian
+# (Debian check is also true on Ubuntu, so Ubuntu must be first)
+# If neither, check for SUSE.
+# If no check succeeds, assume it's Red Hat-based
 if ISUBU
 httpdir = $(sysconfdir)/apache2/sites-available/
-endif
-
-# Assume RHEL Layout
+else
+if ISDEB
+httpdir = $(sysconfdir)/apache2/conf.d/
+else
+if ISSUSE
+httpdir = $(sysconfdir)/apache2/conf.d/
+else
 httpdir = $(sysconfdir)/httpd/conf.d/
+endif
+endif
+endif
 httpdconfdir = $(httpdir)
 
 dist_conf_DATA = provision.conf livesync.conf dhcpd-template.conf dnsmasq-template.conf

--- a/provision/etc/Makefile.am
+++ b/provision/etc/Makefile.am
@@ -3,16 +3,19 @@ SUBDIRS = defaults filesystem
 confdir = $(sysconfdir)/warewulf/
 bash_completiondir = $(sysconfdir)/bash_completion.d/
 
+# Assume RHEL Layout
+httpdir = $(sysconfdir)/httpd/conf.d/
 # Check for Debian
 if ISDEB
 httpdir = $(sysconfdir)/apache2/conf.d/
-else
+endif
+# Check for SUSE
 if ISSUSE
 httpdir = $(sysconfdir)/apache2/conf.d/
-else
-# Assume RHEL Layout
-httpdir = $(sysconfdir)/httpd/conf.d/
 endif
+# Check for Ubuntu
+if ISUBU
+httpdir = $(sysconfdir)/apache2/sites-available/
 endif
 
 httpdconfdir = $(httpdir)

--- a/provision/etc/Makefile.am
+++ b/provision/etc/Makefile.am
@@ -3,8 +3,6 @@ SUBDIRS = defaults filesystem
 confdir = $(sysconfdir)/warewulf/
 bash_completiondir = $(sysconfdir)/bash_completion.d/
 
-# Assume RHEL Layout
-httpdir = $(sysconfdir)/httpd/conf.d/
 # Check for Debian
 if ISDEB
 httpdir = $(sysconfdir)/apache2/conf.d/
@@ -18,6 +16,8 @@ if ISUBU
 httpdir = $(sysconfdir)/apache2/sites-available/
 endif
 
+# Assume RHEL Layout
+httpdir = $(sysconfdir)/httpd/conf.d/
 httpdconfdir = $(httpdir)
 
 dist_conf_DATA = provision.conf livesync.conf dhcpd-template.conf dnsmasq-template.conf

--- a/vnfs/libexec/wwmkchroot/Makefile.am
+++ b/vnfs/libexec/wwmkchroot/Makefile.am
@@ -1,6 +1,6 @@
 wwmkchrootdir = $(libexecdir)/warewulf/wwmkchroot
 
-dist_wwmkchroot_SCRIPTS = centos-5.tmpl centos-6.tmpl centos-7.tmpl include-rhel rhel-generic.tmpl sl-5.tmpl sl-6.tmpl sl-7.tmpl functions include-deb debian-8.tmpl debian7-32.tmpl debian7-64.tmpl golden-system.tmpl include-suse opensuse-42.3.tmpl opensuse-15.0.tmpl opensuse-tumbleweed.tmpl sles-11.tmpl sles-12.tmpl include-ubuntu ubuntu-16.04.tmpl
+dist_wwmkchroot_SCRIPTS = centos-5.tmpl centos-6.tmpl centos-7.tmpl include-rhel rhel-generic.tmpl sl-5.tmpl sl-6.tmpl sl-7.tmpl functions include-deb debian-8.tmpl debian7-32.tmpl debian7-64.tmpl golden-system.tmpl include-suse opensuse-42.3.tmpl opensuse-15.0.tmpl opensuse-15.1.tmpl opensuse-tumbleweed.tmpl sles-11.tmpl sles-12.tmpl include-ubuntu ubuntu-16.04.tmpl ubuntu-18.04
  
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/vnfs/libexec/wwmkchroot/Makefile.am
+++ b/vnfs/libexec/wwmkchroot/Makefile.am
@@ -1,6 +1,6 @@
 wwmkchrootdir = $(libexecdir)/warewulf/wwmkchroot
 
-dist_wwmkchroot_SCRIPTS = centos-5.tmpl centos-6.tmpl centos-7.tmpl include-rhel rhel-generic.tmpl sl-5.tmpl sl-6.tmpl sl-7.tmpl functions include-deb debian-8.tmpl debian7-32.tmpl debian7-64.tmpl golden-system.tmpl include-suse opensuse-42.3.tmpl opensuse-15.0.tmpl opensuse-15.1.tmpl opensuse-tumbleweed.tmpl sles-11.tmpl sles-12.tmpl include-ubuntu ubuntu-16.04.tmpl ubuntu-18.04
+dist_wwmkchroot_SCRIPTS = centos-5.tmpl centos-6.tmpl centos-7.tmpl include-rhel rhel-generic.tmpl sl-5.tmpl sl-6.tmpl sl-7.tmpl functions include-deb debian-8.tmpl debian7-32.tmpl debian7-64.tmpl golden-system.tmpl include-suse opensuse-42.3.tmpl opensuse-15.0.tmpl opensuse-15.1.tmpl opensuse-tumbleweed.tmpl sles-11.tmpl sles-12.tmpl include-ubuntu ubuntu-16.04.tmpl ubuntu-18.04.tmpl
  
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/vnfs/libexec/wwmkchroot/include-suse
+++ b/vnfs/libexec/wwmkchroot/include-suse
@@ -71,16 +71,15 @@ prechroot() {
     fi
 
     if [ -n "${ZYP_MIRROR}" ]; then
-        declare -i i=0 cnt
-        cnt=$($ZYP_CMD lr | grep '|' | wc -l)
-        while [ $i -lt $cnt ]; do
-            $ZYP_CMD rr $i
-            let i++
+
+        while `$ZYP_CMD -x lr | grep -q '</repo>'`; do
+            $ZYP_CMD rr 1
         done
 
         cnt=0
-        for i in `echo $ZYP_MIRROR | sed -e 's/,/ /'`; do
-            $ZYP_CMD ar $i repo-$((cnt++))
+        for i in `echo $ZYP_MIRROR | sed -e 's#,# #'`; do
+            $ZYP_CMD ar $i repo-$cnt
+	    let cnt++
         done
     fi
 
@@ -90,7 +89,7 @@ prechroot() {
 }
 
 postchroot() {
-    for i in `echo $ZYP_MIRROR | sed -e 's/,/ /'`; do
+    for i in `echo $ZYP_MIRROR | sed -e 's#,# #'`; do
         $ZYP_CMD rr $i
     done
     touch $CHROOTDIR/fastboot
@@ -99,3 +98,4 @@ postchroot() {
 
 
 # vim:filetype=sh:syntax=sh:expandtab:ts=4:sw=4:
+

--- a/vnfs/libexec/wwmkchroot/opensuse-15.1.tmpl
+++ b/vnfs/libexec/wwmkchroot/opensuse-15.1.tmpl
@@ -1,0 +1,21 @@
+# The general SUSE include has all of the necessary functions, but requires
+# some basic variables specific to each chroot type to be defined.
+. include-suse
+
+
+
+# Define the location of the YUM repository
+ZYP_MIRROR="http://download.opensuse.org/distribution/leap/15.1/repo/oss/,\
+http://download.opensuse.org/update/leap/15.1/oss/"
+
+# Install only what is necessary/specific for this distribution
+PKGLIST="systemd-sysvinit aaa_base bash dracut openSUSE-release coreutils \
+    e2fsprogs ethtool filesystem findutils gawk grep iproute2 iputils \
+    mingetty net-tools nfs-kernel-server pam rpcbind procps psmisc shadow \
+    rsync sed rsyslog tcpd timezone util-linux tar less gzip kmod-compat \
+    udev openssh dhcp-client pciutils vim strace cron cpupower cpio wget zypper"
+
+
+
+
+# vim:filetype=sh:syntax=sh:expandtab:ts=4:sw=4:


### PR DESCRIPTION
Update for OpenSUSE 15. Verified working on OpenSUSE 15.1
Also included additional updates/fixes for Ubunutu 18.04. Validated on Ubunutu 18.04

Summary of changes: 
- Add wwmkchroot for opensuse15.1, based on opensuse15.0.
- Fixed bug in include-suse. No reason to typecast temporary variables in bash, especially when the same variable is reused for different types.
- Added Ubuntu check in /provision configure.ac. Site config is placed in the sites-available directory. Softlink to active sites is still done manually.
- Updated vnfs Makefile.am to install new Ubuntu and SUSE templates
- Add support for tftp(server) "Provides" in tftp rpm needed by OpenSUSE 15
- Fix suse.pm so that it doesn't try to chomp empty hash
 
Example uild scripts included in /platform. Validation done on headnode and single compute node. Minimal installation. WW provision and default/* configuration files updated manually. Apache, dhcp, and tftp services activated. "wwinit all" performed. No updates to node image after wwmkchroot complete. Confirmed node iPXE boot and ssh access to it from the headnode.
