### PR TITLE
adding ipxe chainloading from VirtualBox netboot that is also using ipxe

### DIFF
--- a/provision/3rd_party/GPL/Makefile.am
+++ b/provision/3rd_party/GPL/Makefile.am
@@ -1,4 +1,4 @@
-dist_gplsrc_DATA = README busybox-1.26.2.tar.bz2 e2fsprogs-1.42.12.tar.gz ipxe-041d362.tar.xz parted-3.2.tar.xz
+dist_gplsrc_DATA = README busybox-1.26.2.tar.bz2 e2fsprogs-1.42.12.tar.gz ipxe-041d362.tar.xz parted-3.2.tar.xz warewulf.ipxe
 
 gplsrcdir = $(prefix)/src/warewulf/3rd_party/GPL/
 

--- a/provision/3rd_party/GPL/warewulf.ipxe
+++ b/provision/3rd_party/GPL/warewulf.ipxe
@@ -1,0 +1,4 @@
+#!ipxe
+set user-class warewulf
+autoboot
+

--- a/provision/3rd_party/Makefile.am
+++ b/provision/3rd_party/Makefile.am
@@ -8,6 +8,7 @@ all: $(IPXETARGETS)
 
 IPXE_VERSION = 041d362
 IPXE_SOURCE = $(top_srcdir)/3rd_party/GPL/ipxe-$(IPXE_VERSION).tar.xz
+IPXE_WW = $(top_srcdir)/3rd_party/GPL/warewulf.ipxe
 IPXE_DIR = ipxe-$(IPXE_VERSION)
 
 
@@ -16,12 +17,13 @@ prep:
 		echo "Extracting IPXE" ;\
 		mkdir -p _work/ ;\
 		tar -xJf $(IPXE_SOURCE) -C _work/ ;\
+		cp -f $(IPXE_WW)  _work/$(IPXE_DIR)/src ;\
 	fi
 
 bin-i386-pcbios/undionly.kpxe: prep
 
 if BUILD_X86_64
-	$(MAKE) -C _work/$(IPXE_DIR)/src CROSS_COMPILE=$(CROSS_COMPILE_X86_64) bin-i386-pcbios/undionly.kpxe
+	$(MAKE) -C _work/$(IPXE_DIR)/src CROSS_COMPILE=$(CROSS_COMPILE_X86_64) bin-i386-pcbios/undionly.kpxe EMBED=warewulf.ipxe
 endif
 
 bin-x86_64-efi/snp.efi: prep

--- a/provision/etc/dhcpd-template.conf
+++ b/provision/etc/dhcpd-template.conf
@@ -12,23 +12,26 @@ option ipxe.no-pxedhcp 1;
 option architecture-type   code 93  = unsigned integer 16;
 
 if exists user-class and option user-class = "iPXE" {
-    filename "http://%{IPADDR}/WW/ipxe/cfg/${mac}";
+    filename "/warewulf/ipxe/bin-i386-pcbios/undionly.kpxe";
 } else {
-    if option architecture-type = 00:0B {
-        filename "/warewulf/ipxe/bin-arm64-efi/snp.efi";
-    } elsif option architecture-type = 00:0A {
-        filename "/warewulf/ipxe/bin-arm32-efi/placeholder.efi";
-    } elsif option architecture-type = 00:09 {
-        filename "/warewulf/ipxe/bin-x86_64-efi/snp.efi";
-    } elsif option architecture-type = 00:07 {
-        filename "/warewulf/ipxe/bin-x86_64-efi/snp.efi";
-    } elsif option architecture-type = 00:06 {
-        filename "/warewulf/ipxe/bin-i386-efi/snp.efi";
-    } elsif option architecture-type = 00:00 {
-        filename "/warewulf/ipxe/bin-i386-pcbios/undionly.kpxe";
+    if exists user-class and option user-class = "warewulf" {
+        filename "http://%{IPADDR}/WW/ipxe/cfg/${mac}";
+    } else {
+        if option architecture-type = 00:0B {
+            filename "/warewulf/ipxe/bin-arm64-efi/snp.efi";
+        } elsif option architecture-type = 00:0A {
+            filename "/warewulf/ipxe/bin-arm32-efi/placeholder.efi";
+        } elsif option architecture-type = 00:09 {
+            filename "/warewulf/ipxe/bin-x86_64-efi/snp.efi";
+        } elsif option architecture-type = 00:07 {
+            filename "/warewulf/ipxe/bin-x86_64-efi/snp.efi";
+        } elsif option architecture-type = 00:06 {
+            filename "/warewulf/ipxe/bin-i386-efi/snp.efi";
+        } elsif option architecture-type = 00:00 {
+            filename "/warewulf/ipxe/bin-i386-pcbios/undionly.kpxe";
+        }
     }
 }
-
 subnet %{NETWORK} netmask %{NETMASK} {
    not authoritative;
    # option interface-mtu 9000;


### PR DESCRIPTION
- netbooting with virtualbox is using ipxe and send the iPXE tag which is caught by the dhcpd-template.conf
- but the vbox provided version ipxe version  is size limited and lack the capacity to boot from  initrd/kernel provided by warewulf setup
- I propose to change de iPXE tag with a "warewulf" tag and chainload the "warewulf" tagged undionly.kpxe


