### PR TITLE
Detect iPXE features

### DIFF
--- a/provision/etc/dhcpd-template.conf
+++ b/provision/etc/dhcpd-template.conf
@@ -3,15 +3,23 @@ allow bootp;
 ddns-update-style interim;
 authoritative;
 
+# Declare the iPXE option space
 option space ipxe;
 
 # Tell iPXE to not wait for ProxyDHCP requests to speed up boot.
 option ipxe.no-pxedhcp code 176 = unsigned integer 8;
 option ipxe.no-pxedhcp 1;
 
+option ipxe-encap-opts code 175 = encapsulate ipxe;
+
+# iPXE feature flags, set in DHCP request packet
+option ipxe.http      code 19 = unsigned integer 8;
+option ipxe.bzimage   code 24 = unsigned integer 8;
+option ipxe.efi       code 36 = unsigned integer 8;
+
 option architecture-type   code 93  = unsigned integer 16;
 
-if exists user-class and option user-class = "iPXE" {
+if exists ipxe.http and ( exists ipxe.bzimage or exists ipxe.efi ) {
     filename "http://%{IPADDR}/WW/ipxe/cfg/${mac}";
 } else {
     if option architecture-type = 00:0B {


### PR DESCRIPTION
Detect if iPXE has the features needed for Warewulf:
- ipxe.http - fetch the kernel and initrd over http
- ipxe.bzimage - Linux bzImage format kernels
or
- ipxe.efi - Linux kernel supporting EFI_STUB, eg. for EFI boot support

If features are missing (including if its not iPXE at all) chainload our iPXE based on architecture.