### PR TITLE
Fixed stateful provisioning UEFI boot settings for aarch64

### DIFF
--- a/provision/initramfs/capabilities/setup-filesystems/80-mkbootable
+++ b/provision/initramfs/capabilities/setup-filesystems/80-mkbootable
@@ -75,7 +75,7 @@ check_efi() {
 check_grubx() {
   local GRUBX
 
-  for GRUBX in "${NEWROOT}"/boot/efi/EFI/*/grubx64.efi; do
+  for GRUBX in "${NEWROOT}"/boot/efi/EFI/*/grub*64.efi; do
     if [ -e "${GRUBX}" ]; then
       return 0
     fi


### PR DESCRIPTION
This patch fixed stateful provisioning UEFI boot settings for aarch64
so as not to call grub2-install by checking the existance of
/boot/efi/EFI/*/grubaa64.efi in the same way as grubx64.efi for
x86_64.

Without this fix, wrong grub boot entry is created and the boot from
local disk fails.

This problem was originally reported from OpenHPC 1.3.8 CentOS 7.6
aarch64 user.
