### PR TITLE
Centos8 Updates

### DIFF
--- a/cluster/configure.ac
+++ b/cluster/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT(warewulf-cluster, 3.8.2, warewulf-devel@lbl.gov)
+AC_INIT(warewulf-cluster, 3.9, warewulf-devel@lbl.gov)
 AC_CONFIG_SRCDIR([.])
 
 AC_PROG_INSTALL

--- a/cluster/libexec/wwinit/50-ntpd.init
+++ b/cluster/libexec/wwinit/50-ntpd.init
@@ -22,12 +22,12 @@ wwreqroot
 
 if  rpm -q chrony >/dev/null 2>&1 ; then
     wwprint "Chrony found; skipping NTP configuration\n"
-    return 0
+    exit 0
 fi
 
 if [ ! -f "/etc/ntp.conf" ]; then
     wwprint "Is NTP installed? /etc/ntp.conf is not present!\n" error
-    return 1
+    exit 1
 fi
 
 

--- a/cluster/libexec/wwinit/50-ntpd.init
+++ b/cluster/libexec/wwinit/50-ntpd.init
@@ -20,6 +20,11 @@ fi
 
 wwreqroot
 
+if  rpm -q chrony >/dev/null 2>&1 ; then
+    wwprint "Chrony found; skipping NTP configuration\n"
+    return 0
+fi
+
 if [ ! -f "/etc/ntp.conf" ]; then
     wwprint "Is NTP installed? /etc/ntp.conf is not present!\n" error
     return 1

--- a/common/configure.ac
+++ b/common/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT(warewulf-common, 3.8.2, warewulf-devel@lbl.gov)
+AC_INIT(warewulf-common, 3.9, warewulf-devel@lbl.gov)
 AC_CONFIG_SRCDIR([.])
 
 AC_PROG_INSTALL

--- a/ipmi/configure.ac
+++ b/ipmi/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT(warewulf-ipmi, 3.8.2, warewulf-devel@lbl.gov)
+AC_INIT(warewulf-ipmi, 3.9, warewulf-devel@lbl.gov)
 AC_CONFIG_SRCDIR([.])
 
 AC_PROG_INSTALL

--- a/platform/build-CentOS-8.sh
+++ b/platform/build-CentOS-8.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+dnf install autoconf automake libacl-devel libattr-devel libuuid-devel nfs-utils device-mapper-devel xz-devel httpd tftp dhcp-server xinetd tcpdump python3-policycoreutils util-linux mariadb-server perl-DBD-mysql openssl-devel wget gcc ipmitool ipxe-bootimgs python3 make libtirpc-devel parted autofs bzip2 chrony perl-CGI tar e2fsprogs libarchive bsdtar
+dnf install perl-Sys-Syslog tftp-server perl-JSON-PP
+
+if [ $? -eq 0 ]; then
+    for SUBDIR in common cluster vnfs ipmi provision; do
+        OPTIONS=" "
+        cd ../$SUBDIR
+        if [ $? -ne 0 ]; then
+            break
+        fi
+        if [ "$SUBDIR" = "provision" ]; then
+	  OPTIONS="--with-apache2moddir=/usr/lib64/apache2 --with-local-e2fsprogs  --with-local-libarchive --with-local-parted --with-local-partprobe"
+        fi
+	if [ "$SUBDIR" = "ipmi" ]; then
+          OPTIONS="--with-local-ipmitool"
+        fi
+          ./autogen.sh --prefix=/ --bindir=/usr/bin $OPTIONS
+        if [ $? -eq 0 ]; then
+            make
+        else
+            echo "$SUBDIR: autogen failed"
+            break
+        fi
+        if [ $? -eq 0 ]; then
+            make install
+        else
+            echo "$SUBDIR: make failed"
+            break
+        fi
+        if [ $? -ne 0 ]; then
+            echo "$SUBDIR: make install failed"
+            break
+        fi
+    done
+fi

--- a/platform/build-CentOS-8.sh
+++ b/platform/build-CentOS-8.sh
@@ -2,7 +2,7 @@
 
 dnf install autoconf automake libacl-devel libattr-devel libuuid-devel nfs-utils device-mapper-devel xz-devel httpd tftp dhcp-server xinetd tcpdump python3-policycoreutils util-linux mariadb-server perl-DBD-mysql openssl-devel wget gcc ipmitool ipxe-bootimgs python3 make libtirpc-devel parted autofs bzip2 chrony perl-CGI tar e2fsprogs libarchive bsdtar
 
-dnf install perl-Sys-Syslog tftp-server perl-JSON-PP
+dnf install perl-Sys-Syslog tftp-server perl-JSON-PP mod_perl
 
 if [ $? -eq 0 ]; then
     for SUBDIR in common cluster vnfs ipmi provision; do
@@ -12,7 +12,7 @@ if [ $? -eq 0 ]; then
             break
         fi
         if [ "$SUBDIR" = "provision" ]; then
-	  OPTIONS="--with-apache2moddir=/usr/lib64/apache2 --with-local-e2fsprogs  --with-local-libarchive --with-local-parted --with-local-partprobe"
+	  OPTIONS="--with-local-e2fsprogs  --with-local-libarchive --with-local-parted --with-local-partprobe"
         fi
 	if [ "$SUBDIR" = "ipmi" ]; then
           OPTIONS="--with-local-ipmitool"

--- a/platform/build-CentOS-8.sh
+++ b/platform/build-CentOS-8.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 dnf install autoconf automake libacl-devel libattr-devel libuuid-devel nfs-utils device-mapper-devel xz-devel httpd tftp dhcp-server xinetd tcpdump python3-policycoreutils util-linux mariadb-server perl-DBD-mysql openssl-devel wget gcc ipmitool ipxe-bootimgs python3 make libtirpc-devel parted autofs bzip2 chrony perl-CGI tar e2fsprogs libarchive bsdtar
+
 dnf install perl-Sys-Syslog tftp-server perl-JSON-PP
 
 if [ $? -eq 0 ]; then

--- a/provision/configure.ac
+++ b/provision/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT([warewulf-provision], [3.8.2], [warewulf-devel@lbl.gov])
+AC_INIT([warewulf-provision], [3.9], [warewulf-devel@lbl.gov])
 AC_CONFIG_SRCDIR([.])
 
 AC_PROG_INSTALL

--- a/provision/initramfs/capabilities/transport-http/wwgetfiles
+++ b/provision/initramfs/capabilities/transport-http/wwgetfiles
@@ -54,9 +54,10 @@ elif [ -f "$TIMESTAMP_FILE" ]; then
 fi
 
 while true; do
+    echo == wwgetfiles == >> /error.log
     for master in `echo $WWMASTER | sed -e 's/,/ /g'`; do
         TMPFILE=`mktemp`
-        if wget -q -O "$TMPFILE" "http://$master/WW/file?hwaddr=$WWINIT_HWADDR&timestamp=$TIMESTAMP" 2>/dev/null; then
+        if wget -q -O "$TMPFILE" "http://$master/WW/file?hwaddr=$WWINIT_HWADDR&timestamp=$TIMESTAMP" 2>>/error.log; then
             cat $TMPFILE | while read id name uid gid mode timestamp path; do
                 basedir=`dirname $path`
                 case "$mode" in

--- a/provision/initramfs/capabilities/transport-http/wwgetnodeconfig
+++ b/provision/initramfs/capabilities/transport-http/wwgetnodeconfig
@@ -10,8 +10,9 @@
 . /warewulf/transports/http/functions
 
 while true; do
+    echo == wwgetnodeconfig == >> /error.log
     for master in `echo $WWMASTER | sed -e 's/,/ /g'`; do
-        if wget -q -O - "http://$master/WW/nodeconfig?hwaddr=$WWINIT_HWADDR" 2>/dev/null; then
+        if wget -q -O - "http://$master/WW/nodeconfig?hwaddr=$WWINIT_HWADDR" 2>>/error.log; then
             exit 0
         fi
     done

--- a/provision/initramfs/capabilities/transport-http/wwgetscript
+++ b/provision/initramfs/capabilities/transport-http/wwgetscript
@@ -27,8 +27,9 @@ case $1 in
 esac
 
 while true; do
+    echo == wwgetscript == >> /error.log
     for master in `echo $WWMASTER | sed -e 's/,/ /g'`; do
-        if wget -q -O - "http://$master/WW/script?hwaddr=$WWINIT_HWADDR&type=$TYPE" 2>/dev/null; then
+        if wget -q -O - "http://$master/WW/script?hwaddr=$WWINIT_HWADDR&type=$TYPE" 2>>/error.log; then
             exit 0
         fi
     done

--- a/provision/initramfs/capabilities/transport-http/wwgetvnfs
+++ b/provision/initramfs/capabilities/transport-http/wwgetvnfs
@@ -19,10 +19,11 @@ VALIDATE_VNFS="${WWVALIDATE_VNFS:-0}"
 cd "${NEWROOT:-/}"
 
 while true; do
+    echo == wwgetvnfs == >> /error.log
     for master in $(echo "${WWMASTER}" | sed -e 's/,/ /g'); do
 
-        rm -f /tmp/vnfs-download /tmp/vnfs-checksum /tmp/vnfs-extract 2>/dev/null
-        if ! mkfifo /tmp/vnfs-download /tmp/vnfs-checksum /tmp/vnfs-extract 2>/dev/null; then
+        rm -f /tmp/vnfs-download /tmp/vnfs-checksum /tmp/vnfs-extract 2>>/error.log
+        if ! mkfifo /tmp/vnfs-download /tmp/vnfs-checksum /tmp/vnfs-extract 2>>/error.log; then
             echo "ERROR: Could not create the fifo!"
             exit 1
         fi
@@ -32,7 +33,7 @@ while true; do
             tee /tmp/vnfs-extract < /tmp/vnfs-download > /tmp/vnfs-checksum &
             TEE_PID=$!
             
-            gunzip < /tmp/vnfs-extract | bsdtar -pxf - 2>/dev/null &
+            gunzip < /tmp/vnfs-extract | bsdtar -pxf - 2>>/error.log &
             EXTRACT_PID=$!
             
             md5sum /tmp/vnfs-checksum > /tmp/wwgetvnfs_checksum &
@@ -48,7 +49,7 @@ while true; do
         wwlogger "vnfs ${WWVNFS_NAME}, ${WWVNFSID}, ${WWVNFS_CHECKSUM:-undef}"
         msg_gray "   * fetching ${WWVNFS_NAME} (ID:${WWVNFSID})"
 
-        wget -q -O /tmp/vnfs-download "http://$master/WW/vnfs?hwaddr=$WWINIT_HWADDR" >/dev/null 2>&1
+        wget -q -O /tmp/vnfs-download "http://$master/WW/vnfs?hwaddr=$WWINIT_HWADDR" >>/error.log 2>&1
         WGETEXIT=$?
 
         if [ "${WGETEXIT}" -eq 0 ]; then
@@ -68,7 +69,7 @@ while true; do
             } || wwfailure
         else
             wwretrying
-            kill "${EXTRACT_PID}" "${TEE_PID:-}" "${MD5SUM_PID:-}" 2>/dev/null || true
+            kill "${EXTRACT_PID}" "${TEE_PID:-}" "${MD5SUM_PID:-}" 2>>/error.log || true
             continue
         fi
 

--- a/vnfs/bin/wwvnfs
+++ b/vnfs/bin/wwvnfs
@@ -23,7 +23,10 @@ use Fcntl ':mode';
 use POSIX;
 {
     local $^W = 0;
-    require "sys/sysmacros.ph";
+    $ENV{PATH} = '/bin:/usr/bin';
+    if (eval { require "sys/sysmacros.ph"; }) {
+      require "sys/sysmacros.ph"
+    }
     require "sys/types.ph";
     require "syscall.ph";
 }

--- a/vnfs/configure.ac
+++ b/vnfs/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT(warewulf-vnfs, 3.8.2, warewulf-devel@lbl.gov)
+AC_INIT(warewulf-vnfs, 3.9, warewulf-devel@lbl.gov)
 AC_CONFIG_SRCDIR([.])
 
 AC_PROG_INSTALL

--- a/vnfs/libexec/wwmkchroot/Makefile.am
+++ b/vnfs/libexec/wwmkchroot/Makefile.am
@@ -1,6 +1,6 @@
 wwmkchrootdir = $(libexecdir)/warewulf/wwmkchroot
 
-dist_wwmkchroot_SCRIPTS = centos-5.tmpl centos-6.tmpl centos-7.tmpl include-rhel rhel-generic.tmpl sl-5.tmpl sl-6.tmpl sl-7.tmpl functions include-deb debian-8.tmpl debian7-32.tmpl debian7-64.tmpl golden-system.tmpl include-suse opensuse-42.3.tmpl opensuse-15.0.tmpl opensuse-15.1.tmpl opensuse-tumbleweed.tmpl sles-11.tmpl sles-12.tmpl include-ubuntu ubuntu-16.04.tmpl ubuntu-18.04.tmpl
+dist_wwmkchroot_SCRIPTS = centos-5.tmpl centos-6.tmpl centos-7.tmpl include-rhel rhel-generic.tmpl sl-5.tmpl sl-6.tmpl sl-7.tmpl functions include-deb debian-8.tmpl debian7-32.tmpl debian7-64.tmpl golden-system.tmpl include-suse opensuse-42.3.tmpl opensuse-15.0.tmpl opensuse-15.1.tmpl opensuse-tumbleweed.tmpl sles-11.tmpl sles-12.tmpl include-ubuntu ubuntu-16.04.tmpl ubuntu-18.04.tmpl centos-8.tmpl include-rhel-dnf
  
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/vnfs/libexec/wwmkchroot/centos-8.tmpl
+++ b/vnfs/libexec/wwmkchroot/centos-8.tmpl
@@ -1,0 +1,27 @@
+#DESC: Red Hat Enterprise Linux 8
+
+# The general RHEL include has all of the necessary functions, but requires
+# some basic variables specific to each chroot type to be defined.
+. include-rhel-dnf
+
+
+
+# Define the location of the YUM repository
+if [ -z "$YUM_MIRROR" ]; then
+    if [ -z "$YUM_MIRROR_BASE" ]; then
+        YUM_MIRROR_BASE="http://mirror.centos.org/centos-7"
+    fi
+    YUM_MIRROR="${YUM_MIRROR_BASE}/7/os/\$basearch/"
+fi
+
+# Install only what is necessary/specific for this distribution
+PKGLIST="basesystem bash chkconfig coreutils e2fsprogs ethtool
+    filesystem findutils gawk grep initscripts iproute iputils
+    net-tools nfs-utils pam psmisc rsync sed setup
+    shadow-utils rsyslog tzdata util-linux words
+    zlib tar less gzip which util-linux openssh-clients 
+    openssh-server dhclient pciutils vim-minimal shadow-utils
+    strace cronie crontabs cpio wget redhat-release"
+
+
+# vim:filetype=sh:syntax=sh:expandtab:ts=4:sw=4:

--- a/vnfs/libexec/wwmkchroot/include-rhel-dnf
+++ b/vnfs/libexec/wwmkchroot/include-rhel-dnf
@@ -1,0 +1,110 @@
+declare -a REPO_NAME
+REPO_NAME[0]="BaseOS"
+REPO_NAME[1]="StreamApp"
+DNF_CONF="/root/dnf-ww.conf"
+DNF_CMD="yum -c $CHROOTDIR/$DNF_CONF -y --installroot $CHROOTDIR"
+declare -a DNF_MIRROR
+DNF_MIRROR[0]=$YUM_MIRROR
+
+distro_check() {
+    if ! rpm -q dnf >/dev/null 2>&1 ; then
+        echo "ERROR: Could not query RPM for DNF"
+        return 1
+    fi
+    return 0
+}
+
+set_overlay() {
+    if [ ! -d "$CHROOTDIR" -o ! -x "$CHROOTDIR/sbin/init" ]; then
+        echo "ERROR: This is an overlay that must work on an existing chroot!"
+        return 1
+    fi
+    if [ ! -f "$CHROOTDIR/etc/redhat-release" ]; then
+        echo "ERROR: This must be a Red Hat compatible chroot!"
+        return 1
+    fi
+    PKGR_CMD="$DNF_CMD install $PKGLIST"
+    return 0
+}
+
+prechroot() {
+    if [ -n "$OS_MIRROR" ]; then
+        DNF_MIRROR[0]="$OS_MIRROR"
+    fi
+    if [[ -z "$DNF_MIRROR[0]" && -z "$INSTALL_ISO" ]]; then
+        echo "ERROR: You must define the \$DNF_MIRROR[] array"
+        cleanup
+        return 1
+    fi
+
+    VERSION=`rpm -qf /etc/redhat-release  --qf '%{VERSION}\n'`
+
+    mkdir -p $CHROOTDIR
+    mkdir -p $CHROOTDIR/etc/dnf
+    
+    cp -rap /etc/dnf/dnf.conf /etc/yum.repos.d $CHROOTDIR/etc
+    sed -i -e "s/\$releasever/$VERSION/g" `find $CHROOTDIR/etc/dnf* -type f`
+
+    DNF_CONF_DIRNAME=`dirname $DNF_CONF`
+    mkdir -m 0755 -p $CHROOTDIR/$DNF_CONF_DIRNAME
+
+    > $CHROOTDIR/$DNF_CONF
+    echo "[main]" >> $CHROOTDIR/$DNF_CONF
+    echo 'cachedir=/var/cache/yum/$basearch/$releasever' >> $CHROOTDIR/$DNF_CONF
+    echo "keepcache=0" >> $CHROOTDIR/$DNF_CONF
+    echo "debuglevel=2" >> $CHROOTDIR/$DNF_CONF
+    echo "logfile=/var/log/dnf.log" >> $CHROOTDIR/$DNF_CONF
+    echo "exactarch=1" >> $CHROOTDIR/$DNF_CONF
+    echo "obsoletes=1" >> $CHROOTDIR/$DNF_CONF
+    echo "gpgcheck=0" >> $CHROOTDIR/$DNF_CONF
+    echo "plugins=1" >> $CHROOTDIR/$DNF_CONF
+    echo "reposdir=0" >> $CHROOTDIR/$DNF_CONF
+    echo "" >> $CHROOTDIR/$DNF_CONF
+
+    if [ -z "$INSTALL_ISO" ]; then
+        echo "[$REPO_NAME[0]]" >> $CHROOTDIR/$DNF_CONF
+        echo 'name=Linux $releasever - $basearch' >> $CHROOTDIR/$DNF_CONF
+        echo "baseurl=$DNF_MIRROR[0]" >> $CHROOTDIR/$DNF_CONF
+        echo "enabled=1" >> $CHROOTDIR/$DNF_CONF
+        echo "gpgcheck=0" >> $CHROOTDIR/$DNF_CONF
+        if [ -n $DNF_MIRROR[1]; then
+            echo "[$REPO_NAME[1]]" >> $CHROOTDIR/$DNF_CONF
+            echo 'name=Linux $releasever - $basearch' >> $CHROOTDIR/$DNF_CONF
+            echo "baseurl=$DNF_MIRROR[1]" >> $CHROOTDIR/$DNF_CONF
+            echo "enabled=1" >> $CHROOTDIR/$DNF_CONF
+            echo "gpgcheck=0" >> $CHROOTDIR/$DNF_CONF
+        fi
+    else
+        for i in `ls -d $MEDIA_MOUNTPATH.*`; do
+            if [ -z "$INSTALLDIRS[0]" ]; then
+                if [ -d $i/BaseOS/repodata ]; then
+                    INSTALLDIRS[0]="file://$i"
+                elif [ -d $i/StreamApp/repodata ]; then
+                    INSTALLDIRS[1]="file://$i"
+                fi
+            fi
+        done
+        echo "[$REPO_NAME[0]]" >> $CHROOTDIR/$DNF_CONF
+        echo 'name=Linux $releasever - $basearch' >> $CHROOTDIR/$DNF_CONF
+        echo "baseurl=$INSTALLDIRS[0]" >> $CHROOTDIR/$DNF_CONF
+        echo "enabled=1" >> $CHROOTDIR/$DNF_CONF
+        echo "gpgcheck=0" >> $CHROOTDIR/$DNF_CONF
+        echo "[$REPO_NAME[1]]" >> $CHROOTDIR/$DNF_CONF
+        echo 'name=Linux $releasever - $basearch' >> $CHROOTDIR/$DNF_CONF
+        echo "baseurl=$INSTALLDIRS[1]" >> $CHROOTDIR/$DNF_CONF
+        echo "enabled=1" >> $CHROOTDIR/$DNF_CONF
+        echo "gpgcheck=0" >> $CHROOTDIR/$DNF_CONF
+
+        DNF_MIRROR=("${INSTALLDIRS[@]}")
+    fi
+    PKGR_CMD="$DNF_CMD install $PKGLIST"
+    return 0
+}
+
+postchroot() {
+    touch $CHROOTDIR/fastboot
+    return 0
+}
+
+
+# vim:filetype=sh:syntax=sh:expandtab:ts=4:sw=4:


### PR DESCRIPTION
Initial updates for CentOS 8. I built a head node and one compute node with this update. Normally, I would do more testing and also recheck against the other distros, but I thought it would be helpful to make this available while I test on CentOS 7, Ubuntu 18, and SLES 15.

Summary of changes

- Updated WW version in configure.ac to expected release version.

- ntp no longer exists in RHEL. I normally test "wwinit all" and the ntp module was throwing an error and then configuring a default ntp.conf file. The module was updated to ignore ntp if it sees chrony installed. TODO: Create a chrony wwinit module; I've been manually configuring it.

- I originally added logic to internally branch the include-redhat script, but it makes it more difficult to edit and read. Instead, I've added a new includes for dnf-based redhat. One major change is a requirement to add a second repo for installation. Without a second repo, the admin would need to manually merge the AppStream and BaseOS repos from the ISO or web.

- Update to wwvnfs to dynamically check for sysmacros.ph before loading. The sysmacros.h file no longer exists in glibc 2.26, so Red Hat removed the .ph from Perl. I'm not even sure its needed on previous distros. I looked at changing the configure and make scripts to update wwvnfs based on OS, but the dynamic check was more expedient.

- Updated scripts in the initrd to dump errors to a log file instead of null. I hit some problems during the provisioning process and its helpful to have error output for review.

- Added my frontend build script to /platform. Again, this is not intended for inclusion in the release, but to provide help identify WW dependencies and build options.