### PR TITLE
Add error capture to initrd HTTP transport scripts

### DIFF
--- a/provision/initramfs/capabilities/provision-vnfs/60-runtimesupport
+++ b/provision/initramfs/capabilities/provision-vnfs/60-runtimesupport
@@ -64,6 +64,6 @@ if [ -z "$WWNORUNTIMESERVICES" ]; then
     echo "WWFQDN=$WWFQDN" >> $NEWROOT/warewulf/config
     echo "export WWFQDN" >> $NEWROOT/warewulf/config
 
-    echo "0,5,10,15,20,25,30,35,40,45,50,55 * * * * root WWGETFILES_INTERVAL=180 /warewulf/bin/wwgetfiles >/var/log/warewulf/wwgetfiles.log 2>&1" > $NEWROOT/etc/cron.d/wwupdatefiles
-    echo "0,5,10,15,20,25,30,35,40,45,50,55 * * * * root . /warewulf/config; /warewulf/bin/wwgetscript runtime 2>/var/log/warewulf/wwgetfiles.log | /bin/sh" > $NEWROOT/etc/cron.d/wwrunscript
+    echo "0,5,10,15,20,25,30,35,40,45,50,55 * * * * root WWGETFILES_INTERVAL=180 /warewulf/bin/wwgetfiles >/var/log/warewulf/provision/wwgetfiles.log 2>&1" > $NEWROOT/etc/cron.d/wwupdatefiles
+    echo "0,5,10,15,20,25,30,35,40,45,50,55 * * * * root . /warewulf/config; /warewulf/bin/wwgetscript runtime 2>/var/log/warewulf/provision/wwgetfiles.log | /bin/sh" > $NEWROOT/etc/cron.d/wwrunscript
 fi

--- a/provision/initramfs/capabilities/transport-http/wwgetfiles
+++ b/provision/initramfs/capabilities/transport-http/wwgetfiles
@@ -54,9 +54,10 @@ elif [ -f "$TIMESTAMP_FILE" ]; then
 fi
 
 while true; do
+    echo "== wwgetfiles ==" >> /tmp/http.log
     for master in `echo $WWMASTER | sed -e 's/,/ /g'`; do
         TMPFILE=`mktemp`
-        if wget -q -O "$TMPFILE" "http://$master/WW/file?hwaddr=$WWINIT_HWADDR&timestamp=$TIMESTAMP" 2>/dev/null; then
+        if wget -q -O "$TMPFILE" "http://$master/WW/file?hwaddr=$WWINIT_HWADDR&timestamp=$TIMESTAMP" 2>>/tmp/http.log; then
             cat $TMPFILE | while read id name uid gid mode timestamp path; do
                 basedir=`dirname $path`
                 case "$mode" in

--- a/provision/initramfs/capabilities/transport-http/wwgetfiles
+++ b/provision/initramfs/capabilities/transport-http/wwgetfiles
@@ -53,11 +53,11 @@ elif [ -f "$TIMESTAMP_FILE" ]; then
     fi
 fi
 
-echo "== wwgetfiles ==" >> /tmp/http.log
+echo "== wwgetfiles ==" >> /var/log/warewulf/provision/http.log
 while true; do
     for master in `echo $WWMASTER | sed -e 's/,/ /g'`; do
         TMPFILE=`mktemp`
-        if wget -q -O "$TMPFILE" "http://$master/WW/file?hwaddr=$WWINIT_HWADDR&timestamp=$TIMESTAMP" 2>>/tmp/http.log; then
+        if wget -q -O "$TMPFILE" "http://$master/WW/file?hwaddr=$WWINIT_HWADDR&timestamp=$TIMESTAMP" 2>>/var/log/warewulf/provision/http.log; then
             cat $TMPFILE | while read id name uid gid mode timestamp path; do
                 basedir=`dirname $path`
                 case "$mode" in

--- a/provision/initramfs/capabilities/transport-http/wwgetfiles
+++ b/provision/initramfs/capabilities/transport-http/wwgetfiles
@@ -53,8 +53,8 @@ elif [ -f "$TIMESTAMP_FILE" ]; then
     fi
 fi
 
+echo "== wwgetfiles ==" >> /tmp/http.log
 while true; do
-    echo "== wwgetfiles ==" >> /tmp/http.log
     for master in `echo $WWMASTER | sed -e 's/,/ /g'`; do
         TMPFILE=`mktemp`
         if wget -q -O "$TMPFILE" "http://$master/WW/file?hwaddr=$WWINIT_HWADDR&timestamp=$TIMESTAMP" 2>>/tmp/http.log; then

--- a/provision/initramfs/capabilities/transport-http/wwgetnodeconfig
+++ b/provision/initramfs/capabilities/transport-http/wwgetnodeconfig
@@ -9,8 +9,8 @@
 
 . /warewulf/transports/http/functions
 
+echo "== wwgetnodeconfig ==" >> /tmp/http.log
 while true; do
-    echo "== wwgetnodeconfig ==" >> /tmp/http.log
     for master in `echo $WWMASTER | sed -e 's/,/ /g'`; do
         if wget -q -O - "http://$master/WW/nodeconfig?hwaddr=$WWINIT_HWADDR" 2>>/tmp/http.log; then
             exit 0

--- a/provision/initramfs/capabilities/transport-http/wwgetnodeconfig
+++ b/provision/initramfs/capabilities/transport-http/wwgetnodeconfig
@@ -10,8 +10,9 @@
 . /warewulf/transports/http/functions
 
 while true; do
+    echo "== wwgetnodeconfig ==" >> /tmp/http.log
     for master in `echo $WWMASTER | sed -e 's/,/ /g'`; do
-        if wget -q -O - "http://$master/WW/nodeconfig?hwaddr=$WWINIT_HWADDR" 2>/dev/null; then
+        if wget -q -O - "http://$master/WW/nodeconfig?hwaddr=$WWINIT_HWADDR" 2>>/tmp/http.log; then
             exit 0
         fi
     done

--- a/provision/initramfs/capabilities/transport-http/wwgetnodeconfig
+++ b/provision/initramfs/capabilities/transport-http/wwgetnodeconfig
@@ -9,10 +9,10 @@
 
 . /warewulf/transports/http/functions
 
-echo "== wwgetnodeconfig ==" >> /tmp/http.log
+echo "== wwgetnodeconfig ==" >> /var/log/warewulf/provision/http.log
 while true; do
     for master in `echo $WWMASTER | sed -e 's/,/ /g'`; do
-        if wget -q -O - "http://$master/WW/nodeconfig?hwaddr=$WWINIT_HWADDR" 2>>/tmp/http.log; then
+        if wget -q -O - "http://$master/WW/nodeconfig?hwaddr=$WWINIT_HWADDR" 2>>/var/log/warewulf/provision/http.log; then
             exit 0
         fi
     done

--- a/provision/initramfs/capabilities/transport-http/wwgetscript
+++ b/provision/initramfs/capabilities/transport-http/wwgetscript
@@ -26,8 +26,8 @@ case $1 in
     ;;
 esac
 
+echo "== wwgetscript ==" >> /tmp/http.log
 while true; do
-    echo "== wwgetscript ==" >> /tmp/http.log
     for master in `echo $WWMASTER | sed -e 's/,/ /g'`; do
         if wget -q -O - "http://$master/WW/script?hwaddr=$WWINIT_HWADDR&type=$TYPE" 2>>/tmp/http.log; then
             exit 0

--- a/provision/initramfs/capabilities/transport-http/wwgetscript
+++ b/provision/initramfs/capabilities/transport-http/wwgetscript
@@ -26,10 +26,10 @@ case $1 in
     ;;
 esac
 
-echo "== wwgetscript ==" >> /tmp/http.log
+echo "== wwgetscript ==" >> /var/log/warewulf/provision/http.log
 while true; do
     for master in `echo $WWMASTER | sed -e 's/,/ /g'`; do
-        if wget -q -O - "http://$master/WW/script?hwaddr=$WWINIT_HWADDR&type=$TYPE" 2>>/tmp/http.log; then
+        if wget -q -O - "http://$master/WW/script?hwaddr=$WWINIT_HWADDR&type=$TYPE" 2>>/var/log/warewulf/provision/http.log; then
             exit 0
         fi
     done

--- a/provision/initramfs/capabilities/transport-http/wwgetscript
+++ b/provision/initramfs/capabilities/transport-http/wwgetscript
@@ -27,8 +27,9 @@ case $1 in
 esac
 
 while true; do
+    echo "== wwgetscript ==" >> /tmp/http.log
     for master in `echo $WWMASTER | sed -e 's/,/ /g'`; do
-        if wget -q -O - "http://$master/WW/script?hwaddr=$WWINIT_HWADDR&type=$TYPE" 2>/dev/null; then
+        if wget -q -O - "http://$master/WW/script?hwaddr=$WWINIT_HWADDR&type=$TYPE" 2>>/tmp/http.log; then
             exit 0
         fi
     done

--- a/provision/initramfs/capabilities/transport-http/wwgetvnfs
+++ b/provision/initramfs/capabilities/transport-http/wwgetvnfs
@@ -18,8 +18,8 @@ VALIDATE_VNFS="${WWVALIDATE_VNFS:-0}"
 
 cd "${NEWROOT:-/}"
 
+echo "== wwgetvnfs ==" >> /tmp/http.log
 while true; do
-    echo "== wwgetvnfs ==" >> /tmp/http.log
     for master in $(echo "${WWMASTER}" | sed -e 's/,/ /g'); do
 
         rm -f /tmp/vnfs-download /tmp/vnfs-checksum /tmp/vnfs-extract 2>>/tmp/http.log

--- a/provision/initramfs/capabilities/transport-http/wwgetvnfs
+++ b/provision/initramfs/capabilities/transport-http/wwgetvnfs
@@ -18,12 +18,12 @@ VALIDATE_VNFS="${WWVALIDATE_VNFS:-0}"
 
 cd "${NEWROOT:-/}"
 
-echo "== wwgetvnfs ==" >> /tmp/http.log
+echo "== wwgetvnfs ==" >> /var/log/warewulf/provision/http.log
 while true; do
     for master in $(echo "${WWMASTER}" | sed -e 's/,/ /g'); do
 
-        rm -f /tmp/vnfs-download /tmp/vnfs-checksum /tmp/vnfs-extract 2>>/tmp/http.log
-        if ! mkfifo /tmp/vnfs-download /tmp/vnfs-checksum /tmp/vnfs-extract 2>>/tmp/http.log; then
+        rm -f /tmp/vnfs-download /tmp/vnfs-checksum /tmp/vnfs-extract 2>>/var/log/warewulf/provision/http.log
+        if ! mkfifo /tmp/vnfs-download /tmp/vnfs-checksum /tmp/vnfs-extract 2>>/var/log/warewulf/provision/http.log; then
             echo "ERROR: Could not create the fifo!"
             exit 1
         fi
@@ -33,7 +33,7 @@ while true; do
             tee /tmp/vnfs-extract < /tmp/vnfs-download > /tmp/vnfs-checksum &
             TEE_PID=$!
             
-            gunzip < /tmp/vnfs-extract | bsdtar -pxf - 2>>/tmp/http.log &
+            gunzip < /tmp/vnfs-extract | bsdtar -pxf - 2>>/var/log/warewulf/provision/http.log &
             EXTRACT_PID=$!
             
             md5sum /tmp/vnfs-checksum > /tmp/wwgetvnfs_checksum &
@@ -49,7 +49,7 @@ while true; do
         wwlogger "vnfs ${WWVNFS_NAME}, ${WWVNFSID}, ${WWVNFS_CHECKSUM:-undef}"
         msg_gray "   * fetching ${WWVNFS_NAME} (ID:${WWVNFSID})"
 
-        wget -q -O /tmp/vnfs-download "http://$master/WW/vnfs?hwaddr=$WWINIT_HWADDR" >>/tmp/http.log 2>&1
+        wget -q -O /tmp/vnfs-download "http://$master/WW/vnfs?hwaddr=$WWINIT_HWADDR" >>/var/log/warewulf/provision/http.log 2>&1
         WGETEXIT=$?
 
         if [ "${WGETEXIT}" -eq 0 ]; then
@@ -69,7 +69,7 @@ while true; do
             } || wwfailure
         else
             wwretrying
-            kill "${EXTRACT_PID}" "${TEE_PID:-}" "${MD5SUM_PID:-}" 2>>/tmp/http.log || true
+            kill "${EXTRACT_PID}" "${TEE_PID:-}" "${MD5SUM_PID:-}" 2>>/var/log/warewulf/provision/http.log || true
             continue
         fi
 

--- a/provision/initramfs/capabilities/transport-http/wwgetvnfs
+++ b/provision/initramfs/capabilities/transport-http/wwgetvnfs
@@ -19,10 +19,11 @@ VALIDATE_VNFS="${WWVALIDATE_VNFS:-0}"
 cd "${NEWROOT:-/}"
 
 while true; do
+    echo "== wwgetvnfs ==" >> /tmp/http.log
     for master in $(echo "${WWMASTER}" | sed -e 's/,/ /g'); do
 
-        rm -f /tmp/vnfs-download /tmp/vnfs-checksum /tmp/vnfs-extract 2>/dev/null
-        if ! mkfifo /tmp/vnfs-download /tmp/vnfs-checksum /tmp/vnfs-extract 2>/dev/null; then
+        rm -f /tmp/vnfs-download /tmp/vnfs-checksum /tmp/vnfs-extract 2>>/tmp/http.log
+        if ! mkfifo /tmp/vnfs-download /tmp/vnfs-checksum /tmp/vnfs-extract 2>>/tmp/http.log; then
             echo "ERROR: Could not create the fifo!"
             exit 1
         fi
@@ -32,7 +33,7 @@ while true; do
             tee /tmp/vnfs-extract < /tmp/vnfs-download > /tmp/vnfs-checksum &
             TEE_PID=$!
             
-            gunzip < /tmp/vnfs-extract | bsdtar -pxf - 2>/dev/null &
+            gunzip < /tmp/vnfs-extract | bsdtar -pxf - 2>>/tmp/http.log &
             EXTRACT_PID=$!
             
             md5sum /tmp/vnfs-checksum > /tmp/wwgetvnfs_checksum &
@@ -48,7 +49,7 @@ while true; do
         wwlogger "vnfs ${WWVNFS_NAME}, ${WWVNFSID}, ${WWVNFS_CHECKSUM:-undef}"
         msg_gray "   * fetching ${WWVNFS_NAME} (ID:${WWVNFSID})"
 
-        wget -q -O /tmp/vnfs-download "http://$master/WW/vnfs?hwaddr=$WWINIT_HWADDR" >/dev/null 2>&1
+        wget -q -O /tmp/vnfs-download "http://$master/WW/vnfs?hwaddr=$WWINIT_HWADDR" >>/tmp/http.log 2>&1
         WGETEXIT=$?
 
         if [ "${WGETEXIT}" -eq 0 ]; then
@@ -68,7 +69,7 @@ while true; do
             } || wwfailure
         else
             wwretrying
-            kill "${EXTRACT_PID}" "${TEE_PID:-}" "${MD5SUM_PID:-}" 2>/dev/null || true
+            kill "${EXTRACT_PID}" "${TEE_PID:-}" "${MD5SUM_PID:-}" 2>>/tmp/http.log || true
             continue
         fi
 


### PR DESCRIPTION
If a wget request fails when booting the node, there is a 30s window to manually login and investigate. The problem is that the http-transport scripts output errors to null.

This update redirects the output to /tmp/http.log instead.