### PR TITLE
CentOS 8 Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,83 +1,197 @@
 jobs:
   build_centos7:
     docker:
-     - image: centos:7
-
-    working_directory: ~/warewulf3
-
+      -
+        image: "centos:7"
     steps:
       - checkout
-      - run:
-          name: Install Build Dependencies
+      -
+        run:
           command: |
-            set -o xtrace
-            yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-            rpmkeys --import /etc/pki/rpm-gpg/RPM-GPG-KEY-*
-            yum -y --exclude=systemtap --exclude=subversion install @development binutils-aarch64-linux-gnu device-mapper-devel gcc-aarch64-linux-gnu libacl-devel libattr-devel libuuid-devel openssl-devel perl-CGI perl-Compress-Raw-Bzip2 perl-Compress-Raw-Zlib perl-DBD-MySQL perl-DBI perl-Digest perl-Digest-MD5 perl-IO-Compress perl-Net-Daemon perl-PlRPC perl-Sys-Syslog perl-Test-Simple xz-devel libtirpc-devel perl-JSON-PP
-      - run:
-          name: Build Common
+              set -o xtrace
+              yum -y install \
+                 https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+              rpmkeys --import /etc/pki/rpm-gpg/RPM-GPG-KEY-*
+              yum -y --exclude=systemtap --exclude=subversion install @development \
+                 binutils-aarch64-linux-gnu device-mapper-devel gcc-aarch64-linux-gnu \
+                 libacl-devel libattr-devel libuuid-devel openssl-devel perl-CGI \
+                 perl-Compress-Raw-Bzip2 perl-Compress-Raw-Zlib perl-DBD-MySQL perl-DBI \
+                 perl-Digest perl-Digest-MD5 perl-IO-Compress perl-Net-Daemon \
+                 perl-PlRPC perl-Sys-Syslog perl-Test-Simple xz-devel libtirpc-devel \
+                 perl-JSON-PP
+          name: "Install Build Dependencies"
+      -
+        run:
           command: |
-            set -o xtrace
-            set -o nounset
-            cd common
-            ./autogen.sh
-            make test
-            make dist-gzip
-            rpmbuild -D "_sourcedir $PWD" -ba ./warewulf-common.spec
-      - run:
-          name: Install warewulf-common
+              set -o xtrace
+              set -o nounset
+              cd common
+              ./autogen.sh
+              make test
+              make dist-gzip
+              rpmbuild -D "_sourcedir $PWD" -ba ./warewulf-common.spec
+          name: "Build Common"
+      -
+        run:
           command: |
-            set -o xtrace
-            set -o nounset
-            GITVERSION=$(git show -s --pretty=format:%h)
-            DIST=$(rpm --eval '%{dist}')
-            yum -y install ~/rpmbuild/RPMS/noarch/warewulf-common-3.8.2-0.${GITVERSION}${DIST}.noarch.rpm
-      - run:
-          name: Build Cluster
+              set -o xtrace
+              set -o nounset
+              GITVERSION=$(git show -s --pretty=format:%h)
+              DIST=$(rpm --eval '%{dist}')
+              yum -y install ~/rpmbuild/RPMS/noarch/\
+              warewulf-common-3.9.0-0.${GITVERSION}${DIST}.noarch.rpm
+          name: "Install warewulf-common"
+      -
+        run:
           command: |
-            set -o xtrace
-            set -o nounset
-            cd cluster
-            ./autogen.sh
-            make dist-gzip
-            rpmbuild -D "_sourcedir $PWD" -ba ./warewulf-cluster.spec
-      - run:
-          name: Build IPMI
+              set -o xtrace
+              set -o nounset
+              cd cluster
+              ./autogen.sh
+              make dist-gzip
+              rpmbuild -D "_sourcedir $PWD" -ba ./warewulf-cluster.spec
+          name: "Build Cluster"
+      -
+        run:
           command: |
-            set -o xtrace
-            set -o nounset
-            cd ipmi
-            ./autogen.sh
-            make dist-gzip
-            rpmbuild -D "_sourcedir $PWD" -ba ./warewulf-ipmi.spec
-      - run:
-          name: Build Provision
+              set -o xtrace
+              set -o nounset
+              cd ipmi
+              ./autogen.sh
+              make dist-gzip
+              rpmbuild -D "_sourcedir $PWD" -ba ./warewulf-ipmi.spec
+          name: "Build IPMI"
+      -
+        run:
           command: |
-            set -o xtrace
-            set -o nounset
-            cd provision
-            ./autogen.sh
-            make dist-gzip
-            rpmbuild -D "_sourcedir $PWD" -D "cross_compile 1" -D "mflags -j$(/usr/bin/getconf _NPROCESSORS_ONLN)" -ba ./warewulf-provision.spec
-      - run:
-          name: Build VNFS
+              set -o xtrace
+              set -o nounset
+              cd provision
+              ./autogen.sh
+              make dist-gzip
+              rpmbuild -D "_sourcedir $PWD" -D "cross_compile 1" \
+                -D "mflags -j$(/usr/bin/getconf _NPROCESSORS_ONLN)" \
+                -ba ./warewulf-provision.spec
+          name: "Build Provision"
+      -
+        run:
           command: |
-            set -o xtrace
-            set -o nounset
-            cd vnfs
-            ./autogen.sh
-            make dist-gzip
-            rpmbuild -D "_sourcedir $PWD" -ba ./warewulf-vnfs.spec
-
-      - store_artifacts:
-          path: ~/rpmbuild/RPMS
+              set -o xtrace
+              set -o nounset
+              cd vnfs
+              ./autogen.sh
+              make dist-gzip
+              rpmbuild -D "_sourcedir $PWD" -ba ./warewulf-vnfs.spec
+          name: "Build VNFS"
+      -
+        store_artifacts:
           destination: RPMS
-      - store_artifacts:
-          path: ~/rpmbuild/SRPMS
+          path: ~/rpmbuild/RPMS
+      -
+        store_artifacts:
           destination: SRPMS
-
+          path: ~/rpmbuild/SRPMS
+    working_directory: ~/warewulf3
+  build_centos8:
+    docker:
+      -
+        image: "centos:8"
+    steps:
+      - checkout
+      -
+        run:
+          command: |
+              set -o xtrace
+              dnf -y install dnf-plugins-core
+              dnf -y config-manager --set-enabled PowerTools
+              dnf -y install \
+                 https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+              rpmkeys --import /etc/pki/rpm-gpg/RPM-GPG-KEY-*
+              dnf -y --exclude=systemtap --exclude=subversion install @development \
+                 device-mapper-devel libacl-devel libattr-devel libuuid-devel \
+                 openssl-devel perl-CGI perl-Compress-Raw-Bzip2 perl-Compress-Raw-Zlib \
+                 perl-DBD-MySQL perl-DBI perl-Digest perl-Digest-MD5 perl-IO-Compress \
+                 perl-Sys-Syslog perl-Test-Simple xz-devel ipmitool parted autofs \
+                 e2fsprogs libarchive perl-Test-Harness perl-JSON-PP bsdtar which \
+                 libtirpc-devel
+          name: "Install Build Dependencies"
+      -
+        run:
+          command: |
+              set -o xtrace
+              set -o nounset
+              cd common
+              ./autogen.sh
+              make test
+              make dist-gzip
+              rpmbuild -D "_sourcedir $PWD" -ba ./warewulf-common.spec
+          name: "Build Common"
+      -
+        run:
+          command: |
+              set -o xtrace
+              set -o nounset
+              GITVERSION=$(git show -s --pretty=format:%h)
+              DIST=$(rpm --eval '%{dist}')
+              yum -y install ~/rpmbuild/RPMS/noarch/\
+              warewulf-common-3.9.0-0.${GITVERSION}${DIST}.noarch.rpm
+          name: "Install warewulf-common"
+      -
+        run:
+          command: |
+              set -o xtrace
+              set -o nounset
+              cd cluster
+              ./autogen.sh
+              make dist-gzip
+              rpmbuild -D "_sourcedir $PWD" -ba ./warewulf-cluster.spec
+          name: "Build Cluster"
+      -
+        run:
+          command: |
+              set -o xtrace
+              set -o nounset
+              cd ipmi
+              ./autogen.sh --with-local-ipmitool=yes
+              make dist-gzip
+              rpmbuild -D "_sourcedir $PWD" -ba ./warewulf-ipmi.spec
+          name: "Build IPMI"
+      -
+        run:
+          command: |
+              set -o xtrace
+              set -o nounset
+              cd provision
+              ./autogen.sh --with-local-e2fsprogs --with-local-libarchive \
+                 --with-local-parted --with-local-partprobe
+              make dist-gzip
+              rpmbuild -D "_sourcedir $PWD" -D "cross_compile 0" \
+                 -D "mflags -j$(/usr/bin/getconf _NPROCESSORS_ONLN)" \
+                 -ba ./warewulf-provision.spec
+          name: "Build Provision"
+      -
+        run:
+          command: |
+              set -o xtrace
+              set -o nounset
+              cd vnfs
+              ./autogen.sh
+              make dist-gzip
+              rpmbuild -D "_sourcedir $PWD" -ba ./warewulf-vnfs.spec
+          name: "Build VNFS"
+      -
+        store_artifacts:
+          destination: RPMS
+          path: ~/rpmbuild/RPMS
+      -
+        store_artifacts:
+          destination: SRPMS
+          path: ~/rpmbuild/SRPMS
+    working_directory: ~/warewulf3
 workflows:
-  version: 2
   build:
     jobs:
       - build_centos7
+      - build_centos8
+  version: 2
+

--- a/cluster/configure.ac
+++ b/cluster/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT(warewulf-cluster, 3.8.2, warewulf-devel@lbl.gov)
+AC_INIT(warewulf-cluster, 3.9.0, warewulf-devel@lbl.gov)
 AC_CONFIG_SRCDIR([.])
 
 AC_PROG_INSTALL

--- a/cluster/libexec/wwinit/52-ntpd.init
+++ b/cluster/libexec/wwinit/52-ntpd.init
@@ -20,35 +20,54 @@ fi
 
 wwreqroot
 
-if [ ! -f "/etc/ntp.conf" ]; then
-    wwprint "Is NTP installed? /etc/ntp.conf is not present!\n" error
-    return 1
+# Check for NTP daemon; if not found, check for chrony
+if ! rpm --quiet -q ntp && ! rpm --quiet -q openntpd; then
+    if rpm --quiet -q chrony; then
+        wwprint "Using chrony; skipping ntp configuration\n"
+        exit 0
+    else
+        wwprint "No time server daemon found!\n" error
+        exit 1
+    fi
 fi
 
+# Backup existing configuration; if backup fails, don't overwrite original
+if [ ! -f "/etc/ntp.conf" ]; then
+    wwprint "No existing /etc/ntp.conf\n" 
+else
+    if cp --backup /etc/ntp.conf /etc/ntp.conf.save; then
+       wwprint "Backed up current NTP config to /etc/ntp.conf.save\n"
+    else
+       wwprint "ERROR: Cannot backup current /etc/ntp.conf\n" error
+       exit 1
+    fi
+fi
 
+# Get network information using Warewulf Perl modules
 NETWORK=`perl -MWarewulf::Network -MWarewulf::Config -e 'print Warewulf::Network->new()->network(Warewulf::Config->new("provision.conf")->get("network device"));'`
 NETMASK=`perl -MWarewulf::Network -MWarewulf::Config -e 'print Warewulf::Network->new()->netmask(Warewulf::Config->new("provision.conf")->get("network device"));'`
 
-ntp_trustedkey=$(cat /etc/ntp.conf | sed -ne "s/^[^#t]*\(trustedkey[^#]\+\).*/\1/p")
+# Pull Secure NTP keys from old config; otherwise set default values
+if [ -f /etc/ntp.conf.save ]; then
+    ntp_trustedkey=$(cat /etc/ntp.conf.save | sed -ne "s/^[^#t]*\(trustedkey[^#]\+\).*/\1/p")
+    ntp_controlkey=$(cat /etc/ntp.conf.save | sed -ne "s/^[^#c]*\(controlkey[^#]\+\).*/\1/p")
+    ntp_requestkey=$(cat /etc/ntp.conf.save | sed -ne "s/^[^#r]*\(requestkey[^#]\+\).*/\1/p")
+fi
 [ -z "$ntp_trustedkey" ] && ntp_trustedkey='#controlkey 8'
-ntp_controlkey=$(cat /etc/ntp.conf | sed -ne "s/^[^#c]*\(controlkey[^#]\+\).*/\1/p")
 [ -z "$ntp_controlkey" ] && ntp_controlkey='#trustedkey 4 8 42'
-ntp_requestkey=$(cat /etc/ntp.conf | sed -ne "s/^[^#r]*\(requestkey[^#]\+\).*/\1/p")
 [ -z "$ntp_requestkey" ] && ntp_requestkey='#requestkey 8'
 
-if ! grep -q "^# This file was created by Warewulf" /etc/ntp.conf; then
-    cp /etc/ntp.conf /etc/ntp.conf-orig
-    wwprint "Backed up current NTP config to /etc/ntp.conf-orig\n"
-fi
-
+# Check for keyfile; otherwise use commented-out RHEL standard location
 if [ -f "/etc/ntp.keys" ]; then
     KEY_FILE="keys /etc/ntp.keys"
 elif [ -f "/etc/ntp/keys" ]; then
     KEY_FILE="keys /etc/ntp/keys"
 else
-    KEY_FILE="#keys /etc/ntp.keys"
+    KEY_FILE="#keys /etc/ntp/keys"
 fi
 
+# Create new copy of /etc/ntp.conf
+# ============================================================ 
 cat <<EOF > /etc/ntp.conf
 # This file was created by Warewulf/wwinit
 #
@@ -94,11 +113,11 @@ $ntp_controlkey
 # Enable writing of statistics records.
 #statistics clockstats cryptostats loopstats peerstats
 EOF
+# ============================================================ 
 
 wwprint "Configured NTP services\n"
 
-wwservice_activate ntp ntpd
+wwservice_activate ntp ntpd openntpd
 RETVAL=$?
-
 
 exit $RETVAL

--- a/cluster/libexec/wwinit/Makefile.am
+++ b/cluster/libexec/wwinit/Makefile.am
@@ -1,6 +1,6 @@
 wwinitdir = $(libexecdir)/warewulf/wwinit
 
-dist_wwinit_SCRIPTS = 30-domain.init 40-authfiles.init 50-dhcp.init 50-network.init 50-nfsd.init 50-ntpd.init 50-ssh_keys.init 50-tftp.init 60-hostfile.init 90-bootstrap.init 91-vnfs.init
+dist_wwinit_SCRIPTS = 30-domain.init 40-authfiles.init 50-dhcp.init 50-network.init 50-nfsd.init 52-ntpd.init 50-ssh_keys.init 50-tftp.init 60-hostfile.init 90-bootstrap.init 91-vnfs.init
 
 MAINTAINERCLEANFILES = Makefile.in
 

--- a/cluster/warewulf-cluster.spec.in
+++ b/cluster/warewulf-cluster.spec.in
@@ -17,7 +17,7 @@ Conflicts: warewulf < 3
 BuildRoot: %{?_tmppath}%{!?_tmppath:/var/tmp}/%{name}-%{version}-%{release}-root
 
 %description
-Warewulf >= 3 is a set of utilities designed to better enable
+Warewulf 3 is a set of utilities designed to better enable
 utilization and maintenance of clusters or groups of computers.
 
 This package contains tools to facilitate management of a Cluster

--- a/common/configure.ac
+++ b/common/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT(warewulf-common, 3.8.2, warewulf-devel@lbl.gov)
+AC_INIT(warewulf-common, 3.9.0, warewulf-devel@lbl.gov)
 AC_CONFIG_SRCDIR([.])
 
 AC_PROG_INSTALL

--- a/common/warewulf-common.spec.in
+++ b/common/warewulf-common.spec.in
@@ -8,11 +8,11 @@ License: US Dept. of Energy (BSD-like)
 Group: System Environment/Clustering
 Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
-Conflicts: warewulf <= 2.9
+Conflicts: warewulf < 3
 BuildArch: noarch
 BuildRoot: %{?_tmppath}/%{name}-%{version}-%{release}-root
 Requires: perl-DBD-MySQL perl-DBD-Pg perl-DBD-SQLite perl-JSON-PP
-%if %{?rhel}%{!?rhel:0} >= 7
+%if 0%{?rhel} >= 7
 Requires: mariadb
 %else
 Requires: mysql
@@ -29,7 +29,7 @@ command line interface.
 Summary: Warewulf - Common Module - Localdb
 Group: System Environment/Clustering
 Requires: %{name} = %{version}-%{release}
-%if %{?rhel}%{!?rhel:0} >= 7
+%if 0%{?rhel} >= 7
 Requires: mariadb-server
 %else
 Requires: mysql-server
@@ -68,7 +68,7 @@ fi
 
 %post localdb
 
-%if %{?rhel}%{!?rhel:0} >= 7
+%if 0%{?rhel} >= 7
 systemctl start mariadb >/dev/null 2>&1 || :
 systemctl enable mariadb >/dev/null 2>&1 || :
 %else

--- a/common/warewulf-common.spec.in
+++ b/common/warewulf-common.spec.in
@@ -11,6 +11,7 @@ ExclusiveOS: linux
 Conflicts: warewulf < 3
 BuildArch: noarch
 BuildRoot: %{?_tmppath}/%{name}-%{version}-%{release}-root
+BuildRequires: autoconf, automake
 Requires: perl-DBD-MySQL perl-DBD-Pg perl-DBD-SQLite perl-JSON-PP
 %if 0%{?rhel} >= 7
 Requires: mariadb
@@ -19,7 +20,7 @@ Requires: mysql
 %endif
 
 %description
-Warewulf >= 3 is a set of utilities designed to better enable
+Warewulf 3 is a set of utilities designed to better enable
 utilization and maintenance of clusters or groups of computers.
 
 This is the main package which includes the common libraries and
@@ -36,12 +37,13 @@ Requires: mysql-server
 %endif
 
 %description localdb
-Warewulf >= 3 is a set of utilities designed to better enable
-utilization and maintenance of clusters or groups of computers.  The
+Warewulf 3 is a set of utilities designed to better enable
+utilization and maintenance of clusters or groups of computers. The
 provision module provides functionality for provisioning, configuring,
 and booting systems.
 
-This package is a metapackage that installs a local MySQL or MariaDB instance. Only for installs that need a local database.
+This package is a metapackage that installs a local MySQL or MariaDB instance.
+Required only for installs that need a local database.
 
 %prep
 %setup -q

--- a/ipmi/configure.ac
+++ b/ipmi/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT(warewulf-ipmi, 3.8.2, warewulf-devel@lbl.gov)
+AC_INIT(warewulf-ipmi, 3.9.0, warewulf-devel@lbl.gov)
 AC_CONFIG_SRCDIR([.])
 
 AC_PROG_INSTALL

--- a/ipmi/warewulf-ipmi.spec.in
+++ b/ipmi/warewulf-ipmi.spec.in
@@ -12,6 +12,7 @@ Group: System Environment/Clustering
 URL: http://warewulf.lbl.gov/
 Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
+Conflicts: warewulf < 3
 Requires: warewulf-common %{name}-initramfs-%{_arch} = %{version}-%{release}
 
 %if 0%{?rhel} >= 8 || 0%{?sle_version} >= 150000
@@ -21,12 +22,10 @@ Requires: ipmitool
 %endif
 
 BuildRequires: warewulf-common openssl-devel
-BuildRequires: autoconf, automake
-Conflicts: warewulf < 3.9
 BuildRoot: %{?_tmppath}%{!?_tmppath:/var/tmp}/%{name}-%{version}-%{release}-root
 
 %description
-Warewulf >= 3 is a set of utilities designed to better enable
+Warewulf 3 is a set of utilities designed to better enable
 utilization and maintenance of clusters or groups of computers.
 
 This is the IPMI module package.  It contains Warewulf modules for

--- a/ipmi/warewulf-ipmi.spec.in
+++ b/ipmi/warewulf-ipmi.spec.in
@@ -13,8 +13,16 @@ URL: http://warewulf.lbl.gov/
 Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
 Requires: warewulf-common %{name}-initramfs-%{_arch} = %{version}-%{release}
+
+%if 0%{?rhel} >= 8 || 0%{?sle_version} >= 150000
+BuildRequires: ipmitool
+Requires: ipmitool
+%define CONF_FLAGS "--with-local-ipmitool=yes"
+%endif
+
 BuildRequires: warewulf-common openssl-devel
-Conflicts: warewulf < 3
+BuildRequires: autoconf, automake
+Conflicts: warewulf < 3.9
 BuildRoot: %{?_tmppath}%{!?_tmppath:/var/tmp}/%{name}-%{version}-%{release}-root
 
 %description
@@ -37,7 +45,7 @@ Warewulf Provisioning initramfs IPMI capabilities for %{_arch}.
 
 
 %build
-%configure
+%configure %{?CONF_FLAGS}
 %{__make} %{?mflags}
 
 
@@ -52,7 +60,9 @@ rm -rf $RPM_BUILD_ROOT
 %files
 %defattr(-,root,root)
 %doc AUTHORS COPYING ChangeLog INSTALL NEWS README TODO
+%if 0%{?rhel} < 8 && 0%{?sle_version} < 150000
 %{_libexecdir}/warewulf/ipmitool
+%endif
 %{perl_vendorlib}/Warewulf/Ipmi.pm
 %{perl_vendorlib}/Warewulf/Module/Cli/*
 

--- a/platform/build-CentOS-8.sh
+++ b/platform/build-CentOS-8.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+dnf install autoconf automake libacl-devel libattr-devel libuuid-devel nfs-utils device-mapper-devel xz-devel httpd tftp dhcp-server xinetd tcpdump python3-policycoreutils util-linux mariadb-server perl-DBD-mysql openssl-devel wget gcc ipmitool ipxe-bootimgs python3 make libtirpc-devel parted autofs bzip2 chrony perl-CGI tar e2fsprogs libarchive bsdtar
+
+dnf install perl-Sys-Syslog tftp-server perl-JSON-PP mod_perl
+
+if [ $? -eq 0 ]; then
+    for SUBDIR in common cluster vnfs ipmi provision; do
+        OPTIONS=" "
+        cd ../$SUBDIR
+        if [ $? -ne 0 ]; then
+            break
+        fi
+        if [ "$SUBDIR" = "provision" ]; then
+	  OPTIONS="--with-local-e2fsprogs  --with-local-libarchive --with-local-parted --with-local-partprobe"
+        fi
+	if [ "$SUBDIR" = "ipmi" ]; then
+          OPTIONS="--with-local-ipmitool"
+        fi
+          ./autogen.sh --prefix=/ --bindir=/usr/bin $OPTIONS
+        if [ $? -eq 0 ]; then
+            make
+        else
+            echo "$SUBDIR: autogen failed"
+            break
+        fi
+        if [ $? -eq 0 ]; then
+            make install
+        else
+            echo "$SUBDIR: make failed"
+            break
+        fi
+        if [ $? -ne 0 ]; then
+            echo "$SUBDIR: make install failed"
+            break
+        fi
+    done
+fi

--- a/provision/configure.ac
+++ b/provision/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT([warewulf-provision], [3.8.2], [warewulf-devel@lbl.gov])
+AC_INIT([warewulf-provision], [3.9.0], [warewulf-devel@lbl.gov])
 AC_CONFIG_SRCDIR([.])
 
 AC_PROG_INSTALL

--- a/provision/warewulf-provision.spec.in
+++ b/provision/warewulf-provision.spec.in
@@ -12,27 +12,33 @@ Group: System Environment/Clustering
 Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
 Requires: warewulf-common %{name}-initramfs-%{_arch} = %{version}-%{release}
-BuildRequires: warewulf-common libselinux-devel libacl-devel libattr-devel libuuid-devel device-mapper-devel xz-devel
+Conflicts: warewulf < 3
+BuildRequires: warewulf-common
+BuildRequires: libselinux-devel libacl-devel libattr-devel
+BuildRequires: libuuid-devel device-mapper-devel xz-devel
+BuildRequires: autoconf automake
 BuildRequires: libtirpc-devel
 
 %if 0%{?_cross_compile}
-
+%global CONF_CROSS --enable-cross-compile %{CONF_FLAGS}
 %if "%{_arch}" == "x86_64"
 BuildRequires: gcc-aarch64-linux-gnu
-%endif
-
+%endif # x86_64
 %if "%{_arch}" == "aarch64"
 BuildRequires: gcc-x86_64-linux-gnu
+%endif # aarch64
+%endif # cross_compile
+
+%if 0%{?rhel} >= 8 || 0%{?sle_version} >= 150000
+BuildRequires: parted e2fsprogs libarchive
+Requires: parted autofs e2fsprogs libarchive
+%global CONF_FLAGS --with-local-e2fsprogs --with-local-libarchive --with-local-parted --with-local-partprobe
 %endif
 
-%endif
-
-
-Conflicts: warewulf < 3
 BuildRoot: %{?_tmppath}%{!?_tmppath:/var/tmp}/%{name}-%{version}-%{release}-root
 
 %description
-Warewulf >= 3 is a set of utilities designed to better enable
+Warewulf 3 is a set of utilities designed to better enable
 utilization and maintenance of clusters or groups of computers.  The
 provision module provides functionality for provisioning, configuring,
 and booting systems.
@@ -114,12 +120,7 @@ available the included GPL software.
 
 %build
 
-%if 0%{?_cross_compile}
-  %configure --enable-cross-compile
-%else
-  %configure
-%endif
-
+%configure %{?CONF_FLAGS} %{?CONF_CROSS}
 %{__make} %{?mflags}
 
 

--- a/provision/warewulf-provision.spec.in
+++ b/provision/warewulf-provision.spec.in
@@ -7,7 +7,7 @@ Summary: Warewulf - Provisioning Module
 Version: @PACKAGE_VERSION@
 Release: %{_rel}%{?dist}
 #Release: 1.%{?_dist}
-License: US Dept. of Energy (BSD-like)
+License: US Dept. of Energy (BSD-like) and BSD-3 Clause
 Group: System Environment/Clustering
 Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
@@ -16,7 +16,6 @@ Conflicts: warewulf < 3
 BuildRequires: warewulf-common
 BuildRequires: libselinux-devel libacl-devel libattr-devel
 BuildRequires: libuuid-devel device-mapper-devel xz-devel
-BuildRequires: autoconf automake
 BuildRequires: libtirpc-devel
 
 %if 0%{?_cross_compile}
@@ -63,7 +62,7 @@ Requires: %{name} = %{version}-%{release} %{name}-server-ipxe-%{_arch} = %{versi
 Requires: mod_perl httpd tftp-server dhcp policycoreutils-python
 
 %description server
-Warewulf >= 3 is a set of utilities designed to better enable
+Warewulf 3 is a set of utilities designed to better enable
 utilization and maintenance of clusters or groups of computers.  The
 provision module provides functionality for provisioning, configuring,
 and booting systems.
@@ -96,11 +95,12 @@ Warewulf bundled iPXE binaries for aarch64.
 %package gpl_sources
 Summary: This package contains the GPL sources used in Warewulf
 Group: Development/System
+License: GPL+
 Requires: %{name} = %{version}-%{release}
 BuildArch: noarch
 
 %description gpl_sources
-Warewulf >= 3 is a set of utilities designed to better enable
+Warewulf 3 is a set of utilities designed to better enable
 utilization and maintenance of clusters or groups of computers.  The
 provision module provides functionality for provisioning, configuring,
 and booting systems.

--- a/vnfs/bin/wwvnfs
+++ b/vnfs/bin/wwvnfs
@@ -23,7 +23,10 @@ use Fcntl ':mode';
 use POSIX;
 {
     local $^W = 0;
-    require "sys/sysmacros.ph";
+    $ENV{PATH} = '/bin:/usr/bin';
+    if (eval { require "sys/sysmacros.ph"; }) {
+      require "sys/sysmacros.ph"
+    }
     require "sys/types.ph";
     require "syscall.ph";
 }

--- a/vnfs/configure.ac
+++ b/vnfs/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT(warewulf-vnfs, 3.8.2, warewulf-devel@lbl.gov)
+AC_INIT(warewulf-vnfs, 3.9.0, warewulf-devel@lbl.gov)
 AC_CONFIG_SRCDIR([.])
 
 AC_PROG_INSTALL

--- a/vnfs/libexec/wwmkchroot/Makefile.am
+++ b/vnfs/libexec/wwmkchroot/Makefile.am
@@ -1,6 +1,6 @@
 wwmkchrootdir = $(libexecdir)/warewulf/wwmkchroot
 
-dist_wwmkchroot_SCRIPTS = centos-5.tmpl centos-6.tmpl centos-7.tmpl include-rhel rhel-generic.tmpl sl-5.tmpl sl-6.tmpl sl-7.tmpl functions include-deb debian-8.tmpl debian7-32.tmpl debian7-64.tmpl golden-system.tmpl include-suse opensuse-42.3.tmpl opensuse-15.0.tmpl opensuse-15.1.tmpl opensuse-tumbleweed.tmpl sles-11.tmpl sles-12.tmpl include-ubuntu ubuntu-16.04.tmpl ubuntu-18.04.tmpl
+dist_wwmkchroot_SCRIPTS = centos-5.tmpl centos-6.tmpl centos-7.tmpl include-rhel rhel-generic.tmpl sl-5.tmpl sl-6.tmpl sl-7.tmpl functions include-deb debian-8.tmpl debian7-32.tmpl debian7-64.tmpl golden-system.tmpl include-suse opensuse-42.3.tmpl opensuse-15.0.tmpl opensuse-15.1.tmpl opensuse-tumbleweed.tmpl sles-11.tmpl sles-12.tmpl include-ubuntu ubuntu-16.04.tmpl ubuntu-18.04.tmpl centos-8.tmpl
  
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/vnfs/libexec/wwmkchroot/centos-6.tmpl
+++ b/vnfs/libexec/wwmkchroot/centos-6.tmpl
@@ -2,9 +2,16 @@
 
 # The general RHEL include has all of the necessary functions, but requires
 # some basic variables specific to each chroot type to be defined.
+
+# Check if we're building the chroot from RHEL/CentOS 8
+if [ $(awk -F= '/VERSION_ID/ {print $2}' < /etc/os-release) = '"8"' ]; then
+     PKG_MGR="dnf"
+     PLATFORMID="platform:el6"
+fi
+
+EXTRA_OPTS="--releasever=6"
+
 . include-rhel
-
-
 
 # Define the location of the YUM repository
 YUM_MIRROR="http://mirror.centos.org/centos-6/6/os/\$basearch/"

--- a/vnfs/libexec/wwmkchroot/centos-8.tmpl
+++ b/vnfs/libexec/wwmkchroot/centos-8.tmpl
@@ -1,34 +1,30 @@
-#DESC: A clone of Red Hat Enterprise Linux 7
+#DESC: Red Hat Enterprise Linux 8
 
 # The general RHEL include has all of the necessary functions, but requires
 # some basic variables specific to each chroot type to be defined.
 
-# Check if we're building the chroot from RHEL/CentOS 8
-if [ $(awk -F= '/VERSION_ID/ {print $2}' < /etc/os-release) = '"8"' ]; then
-     PKG_MGR="dnf"
-     PLATFORMID="platform:el7"
-fi
-
-EXTRA_OPTS="--releasever=7"
+# Use DNF as the package manager
+PKG_MGR=dnf
+EXTRA_OPTS="--releasever=8" 
+PLATFORMID="platform:el8"
 
 . include-rhel
 
 # Define the location of the YUM repository
 if [ -z "$YUM_MIRROR" ]; then
     if [ -z "$YUM_MIRROR_BASE" ]; then
-        YUM_MIRROR_BASE="http://mirror.centos.org/centos-7"
+        YUM_MIRROR_BASE="http://mirror.centos.org/centos-8"
     fi
-    YUM_MIRROR="${YUM_MIRROR_BASE}/7/os/\$basearch/"
+    YUM_MIRROR="${YUM_MIRROR_BASE}/8/BaseOS/\$basearch/os","${YUM_MIRROR_BASE}/8/AppStream/\$basearch/os"
 fi
 
 # Install only what is necessary/specific for this distribution
 PKGLIST="basesystem bash chkconfig coreutils e2fsprogs ethtool
     filesystem findutils gawk grep initscripts iproute iputils
-    net-tools nfs-utils pam psmisc rdate rsync sed setup
-    shadow-utils rsyslog tcp_wrappers tzdata util-linux words
+    net-tools nfs-utils pam psmisc rsync sed setup
+    shadow-utils rsyslog tzdata util-linux words
     zlib tar less gzip which util-linux openssh-clients 
     openssh-server dhclient pciutils vim-minimal shadow-utils
-    strace cronie crontabs cpio wget centos-release"
-
+    strace cronie crontabs cpio wget redhat-release"
 
 # vim:filetype=sh:syntax=sh:expandtab:ts=4:sw=4:

--- a/vnfs/libexec/wwmkchroot/include-rhel
+++ b/vnfs/libexec/wwmkchroot/include-rhel
@@ -1,12 +1,29 @@
-
-REPO_NAME="os-base"
-YUM_CONF="/root/yum-ww.conf"
-YUM_CMD="yum -c $CHROOTDIR/$YUM_CONF --tolerant --installroot $CHROOTDIR -y"
+if [ "$PKG_MGR" = "dnf" ]; then
+    YUM_CONF="/etc/dnf/dnf.conf"
+    YUM_CMD="dnf -y -c $CHROOTDIR/$YUM_CONF --installroot $CHROOTDIR --setopt=reposdir=$CHROOTDIR/etc/yum.repos.d $EXTRA_OPTS" 
+    YUM_REPOCMD="dnf config-manager -y -c $CHROOTDIR/$YUM_CONF --installroot $CHROOTDIR --setopt=reposdir=$CHROOTDIR/etc/yum.repos.d $EXTRA_OPTS"
+else
+    PKG_MGR="yum"    
+    YUM_CONF="/etc/yum.conf"
+    YUM_CMD="yum -y -c $CHROOTDIR/$YUM_CONF --tolerant --installroot $CHROOTDIR $EXTRA_OPTS"
+    YUM_REPOCMD="yum-config-manager -y -c $CHROOTDIR/$YUM_CONF --tolerant --installroot $CHROOTDIR $EXTRA_OPTS"
+fi
 
 distro_check() {
-    if ! rpm -q yum >/dev/null 2>&1 ; then
-        echo "ERROR: Could not query RPM for YUM"
+    if [ "$PKG_MGR" = "dnf" ]; then
+        if ! dnf --version >/dev/null 2>&1 ; then
+        echo "ERROR: dnf command not available"
         return 1
+        fi
+    else 
+        if ! yum --version >/dev/null 2>&1 ; then
+        echo "ERROR: yum command not available"
+        return 1
+        fi
+        if ! yum-config-manager --version >/dev/null 2>&1 ; then
+        echo "ERROR: yum-config-manager command not available"
+        return 1
+        fi
     fi
     return 0
 }
@@ -25,67 +42,58 @@ set_overlay() {
 }
 
 prechroot() {
-    if [ -n "$OS_MIRROR" ]; then
+    if [[ -n "$OS_MIRROR" && -z "$YUM_MIRROR" ]]; then
         YUM_MIRROR="$OS_MIRROR"
     fi
+
     if [[ -z "$YUM_MIRROR" && -z "$INSTALL_ISO" ]]; then
-        echo "ERROR: You must define the \$YUM_MIRROR variable in the template"
+        echo "ERROR: You must define the \$YUM_MIRROR or \$INSTALL_ISO variable"
         cleanup
         return 1
     fi
 
-    VERSION=`rpm -qf /etc/redhat-release  --qf '%{VERSION}\n'`
+    mkdir -p $CHROOTDIR/var/log
+    mkdir -p $CHROOTDIR/var/cache
 
-    mkdir -p $CHROOTDIR
-    mkdir -p $CHROOTDIR/etc
-
-    cp -rap /etc/yum.conf /etc/yum.repos.d $CHROOTDIR/etc
-    sed -i -e "s/\$releasever/$VERSION/g" `find $CHROOTDIR/etc/yum* -type f`
-
-    YUM_CONF_DIRNAME=`dirname $YUM_CONF`
-    mkdir -m 0755 -p $CHROOTDIR/$YUM_CONF_DIRNAME
-
-    > $CHROOTDIR/$YUM_CONF
-    echo "[main]" >> $CHROOTDIR/$YUM_CONF
-    echo 'cachedir=/var/cache/yum/$basearch/$releasever' >> $CHROOTDIR/$YUM_CONF
+    mkdir -m 0755 -p $CHROOTDIR/$(dirname $YUM_CONF)
+    
+    # Write a yum or dnf config file, with minor differences
+    echo "[main]" > $CHROOTDIR/$YUM_CONF
     echo "keepcache=0" >> $CHROOTDIR/$YUM_CONF
     echo "debuglevel=2" >> $CHROOTDIR/$YUM_CONF
-    echo "logfile=/var/log/yum.log" >> $CHROOTDIR/$YUM_CONF
-    echo "exactarch=1" >> $CHROOTDIR/$YUM_CONF
+    echo "logfile=/var/log/$PKG_MGR.log" >> $CHROOTDIR/$YUM_CONF
     echo "obsoletes=1" >> $CHROOTDIR/$YUM_CONF
     echo "gpgcheck=0" >> $CHROOTDIR/$YUM_CONF
     echo "plugins=1" >> $CHROOTDIR/$YUM_CONF
     echo "reposdir=0" >> $CHROOTDIR/$YUM_CONF
+    echo "reposdir=0" >> $CHROOTDIR/$YUM_CONF
+    if [ "$PKG_MGR" = "dnf" ]; then
+        echo "install_weak_deps=0" >> $CHROOTDIR/$YUM_CONF
+        echo "cachedir=/var/cache/dnf" >> $CHROOTDIR/$YUM_CONF
+        # New DNF requires the os-release file with platform ID
+        echo "PLATFORM_ID=\"$PLATFORMID\"" > $CHROOTDIR/etc/os-release
+    else
+        echo "exactarch=1" >> $CHROOTDIR/$YUM_CONF
+        echo "cachedir=/var/cache/yum/\$basearch/\$releasever" >> $CHROOTDIR/$YUM_CONF
+    fi
     echo "" >> $CHROOTDIR/$YUM_CONF
 
-    if [ -z "$INSTALL_ISO" ]; then
-        echo "[$REPO_NAME]" >> $CHROOTDIR/$YUM_CONF
-        echo 'name=Linux $releasever - $basearch' >> $CHROOTDIR/$YUM_CONF
-        echo "baseurl=$YUM_MIRROR" >> $CHROOTDIR/$YUM_CONF
-        echo "enabled=1" >> $CHROOTDIR/$YUM_CONF
-        echo "gpgcheck=0" >> $CHROOTDIR/$YUM_CONF
-    else
-        for i in `ls -d $MEDIA_MOUNTPATH.*`; do
-            if [ -z "$INSTALLDIRS" ]; then
-                if [ -d $i/repodata ]; then
-                    # RHEL 6.x
-                    INSTALLDIRS="file://$i"
-                elif [ -d $i/Server/repodata ]; then
-                    # RHEL 5.x
-                    INSTALLDIRS="file://$i/Server"
-                fi
-            else
-                INSTALLDIRS="$INSTALLDIRS,file://$i"
-            fi
+    # Add all of the repos found on the ISO image
+    if [ -n "$INSTALL_ISO" ]; then
+        for i in $(find $MEDIA_MOUNTPATH -type d -name repodata); do
+             INSTALLDIRS="$INSTALLDIRS,file://$i"
         done
-        echo "[$REPO_NAME]" >> $CHROOTDIR/$YUM_CONF
-        echo 'name=Linux $releasever - $basearch' >> $CHROOTDIR/$YUM_CONF
-        echo "baseurl=$INSTALLDIRS" >> $CHROOTDIR/$YUM_CONF
-        echo "enabled=1" >> $CHROOTDIR/$YUM_CONF
-        echo "gpgcheck=0" >> $CHROOTDIR/$YUM_CONF
-
-        YUM_MIRROR=$INSTALLDIRS
+        YUM_MIRROR="$YUM_MIRROR,$INSTALLDIRS"
     fi
+
+    # Remove all existing repos in CHROOT; just a precaution
+    rm -f $CHROOTDIR/etc/yum.repos.d/*
+    
+    # Create new repos from comma-seperated list (using bash inline S&R)
+    for i in ${YUM_MIRROR//,/ }; do
+        $YUM_REPOCMD --add-repo $i 
+    done
+
     PKGR_CMD="$YUM_CMD install $PKGLIST"
     return 0
 }
@@ -95,14 +103,27 @@ postchroot() {
 
     # we only want to add this kludge to the file once. lets make sure an
     # improperly writen overlay template wont cause repeated file concatenation
-    if grep -q rename_device $CHROOTDIR/etc/sysconfig/network-scripts/network-functions && \
-       ! grep -q 'rename_device() { return 0; }' $CHROOTDIR/etc/sysconfig/network-scripts/network-functions; then
-        echo "" >> $CHROOTDIR/etc/sysconfig/network-scripts/network-functions
-        echo "# This is a kludge added by Warewulf so devices don't get renamed (broke things with IB)" >> $CHROOTDIR/etc/sysconfig/network-scripts/network-functions
-        echo "rename_device() { return 0; }" >> $CHROOTDIR/etc/sysconfig/network-scripts/network-functions
+    # network-functions is not present on RHEL 8
+    NETFILE=$CHROOTDIR/etc/sysconfig/network-scripts/network-functions
+    if [ -f $NETFILE ]; then
+        if grep -q 'rename_device' $NETFILE && ! grep -q 'rename_device() { return 0; }' $NETFILE; then
+            echo "" >> $NETFILE
+            echo "# This is a kludge added by Warewulf so devices don't get renamed (broke things with IB)" >> $NETFILE
+            echo "rename_device() { return 0; }" >> $NETFILE
+        fi
     fi
+
+    # Dracut on newer releases doesn't work within a chroot without sys/proc filesystems mounted.
+    # Post-install scripts on kernel-core RPM will fail
+    # Manually add a pointer to the Linux kernel to /boot
+    # This provides for initrd images to be created from the chroot.
+    for i in $(find $CHROOTDIR/lib/modules -path /*/vmlinuz -printf "%P\n" | cut -d / -f 1); do
+        if [ ! -f /$CHROOTDIR/boot/vmlinuz-$i ]; then
+            ln -s ../lib/modules/$i/vmlinuz $CHROOTDIR/boot/vmlinuz-$i
+        fi
+    done
+
     return 0
 }
-
 
 # vim:filetype=sh:syntax=sh:expandtab:ts=4:sw=4:

--- a/vnfs/warewulf-vnfs.spec.in
+++ b/vnfs/warewulf-vnfs.spec.in
@@ -19,7 +19,7 @@ BuildRoot: %{?_tmppath}%{!?_tmppath:/var/tmp}/%{name}-%{version}-%{release}-root
 # YUM to properly update a package of a different BuildArch...
 
 %description
-Warewulf >= 3 is a set of utilities designed to better enable
+Warewulf 3 is a set of utilities designed to better enable
 utilization and maintenance of clusters or groups of computers.
 
 This is the VNFS module which supports the creation and management of

--- a/vnfs/warewulf-vnfs.spec.in
+++ b/vnfs/warewulf-vnfs.spec.in
@@ -17,7 +17,6 @@ BuildArch: noarch
 BuildRoot: %{?_tmppath}%{!?_tmppath:/var/tmp}/%{name}-%{version}-%{release}-root
 # Previous version had an architecture in its release. This is necessary for
 # YUM to properly update a package of a different BuildArch...
-Obsoletes: warewulf-vnfs < 3.2-0
 
 %description
 Warewulf >= 3 is a set of utilities designed to better enable


### PR DESCRIPTION
CentOS 8 support added to Warewulf

Commits from original PR #203 squashed into this.

This commit does the following:

o   Adds a build for CentOS 8 to CircleCI.
    Cross-compile options are not available in epel8,
    so this options is disabled for now. The RPM specfiles were modified to
    support configure options needed by CentOS8 and SLE15.

o   The Warewulf version was fixed to 3.9.0.

o   Specfiles *.in files updated to support CircleCI changes

o   ntpd init updated. The ntp package is not supported in CentOS 8.
    The init is updated so if ntp is not installed, wwinit doesn't create
    a config by default. A chrony init will need to be created, which will
    run first and skip configuration if ntp is installed.
    OpenNTP is also now supported.

o   Added a template for CentOS 8 nodes and updated the includes template
    - Added DNF support. A flag is used in the template; otherwise it defaults to YUM
    - A dracut workaround was needed to fix copying the kernel to boot. The new
      RHEL8 now uses /sys and /proc to set kernel configuration, which is
      useless for hosting different node image architectures.

o   Added check for sysmacros.ph used by wwvnfs It no longer exists in glibc 2.26.

o    includes copy of my CentOS8 build script in platform. For reference only.

One big change here was I decoupled the chroot package manager configuration from the host pkgmgr configuration. WW 3.8 copies the head node YUM config/repos to the chroot before installation, using a temporary YUM config file. I removed that. Instead, it makes the repos and configuration used during chroot installation permanent within that chroot. The head node and compute node repos remain separate. This allows users on a CentOS 8 or RHEL 8 head node to easily build CentOS 6, 7, or 8 chroot images. I tested building all three of these.