### PR TITLE
Add missing bsdtar RPM requirement to specfile (CentOS8/OpenSUSE15)

### DIFF
--- a/provision/warewulf-provision.spec.in
+++ b/provision/warewulf-provision.spec.in
@@ -29,8 +29,8 @@ BuildRequires: gcc-x86_64-linux-gnu
 %endif # cross_compile
 
 %if 0%{?rhel} >= 8 || 0%{?sle_version} >= 150000
-BuildRequires: parted e2fsprogs libarchive
-Requires: parted autofs e2fsprogs libarchive
+BuildRequires: parted e2fsprogs libarchive bsdtar
+Requires: parted autofs e2fsprogs libarchive bsdtar
 %global CONF_FLAGS --with-local-e2fsprogs --with-local-libarchive --with-local-parted --with-local-partprobe
 %endif
 


### PR DESCRIPTION
Fix for: BuildRequires: bsdtar missing developement version #209.