### PR TITLE
Fix srv/state directory in specfiles

### DIFF
--- a/cluster/warewulf-cluster.spec.in
+++ b/cluster/warewulf-cluster.spec.in
@@ -1,5 +1,6 @@
 %{!?_rel:%{expand:%%global _rel 0.%(test "@GITVERSION@" != "0000" && echo "@GITVERSION@" || git show -s --pretty=format:%h || echo 0000)}}
 %define debug_package %{nil}
+%{!?wwsrvdir:%{expand:%%define wwsrvdir %{_localstatedir}}
 
 Summary: Warewulf - HPC cluster configuration
 Name: warewulf-cluster
@@ -19,7 +20,7 @@ large scale deployments of systems on physical, virtual and cloud-based
 infrastructures. It facilitates elastic and large deployments consisting
 of groups of homogenous systems.
 
-Warewulf Cluster contains tools and libraries to facilitate the initial
+Warewulf Cluster contains tools and libraries to facilitate the
 configuration of a cluster and its nodes.
 
 
@@ -28,7 +29,7 @@ configuration of a cluster and its nodes.
 
 
 %build
-%configure
+%configure --localstatedir=%{wwsrvdir}
 %{__make} %{?mflags}
 
 
@@ -40,7 +41,7 @@ configuration of a cluster and its nodes.
 %defattr(-, root, root)
 %doc AUTHORS ChangeLog INSTALL NEWS README TODO
 %license LICENSE COPYING
-%{_sysconfdir}/profile.d/*
+{_sysconfdir}/profile.d/*
 %{_bindir}/*
 %{_libexecdir}/warewulf/wwinit/*
 %{perl_vendorlib}/Warewulf/Module/Cli/*

--- a/cluster/warewulf-cluster.spec.in
+++ b/cluster/warewulf-cluster.spec.in
@@ -1,6 +1,6 @@
 %{!?_rel:%{expand:%%global _rel 0.%(test "@GITVERSION@" != "0000" && echo "@GITVERSION@" || git show -s --pretty=format:%h || echo 0000)}}
 %define debug_package %{nil}
-%{!?wwsrvdir:%{expand:%%define wwsrvdir %{_localstatedir}}
+%{!?wwsrvdir:%{expand:%%define wwsrvdir %{_localstatedir}}}
 
 Name: warewulf-cluster
 Version: @PACKAGE_VERSION@
@@ -41,7 +41,7 @@ configuration of a cluster and its nodes.
 %defattr(-, root, root)
 %doc AUTHORS ChangeLog INSTALL NEWS README TODO
 %license LICENSE COPYING
-{_sysconfdir}/profile.d/*
+%{_sysconfdir}/profile.d/*
 %{_bindir}/*
 %{_libexecdir}/warewulf/wwinit/*
 %{perl_vendorlib}/Warewulf/Module/Cli/*

--- a/cluster/warewulf-cluster.spec.in
+++ b/cluster/warewulf-cluster.spec.in
@@ -2,10 +2,10 @@
 %define debug_package %{nil}
 %{!?wwsrvdir:%{expand:%%define wwsrvdir %{_localstatedir}}
 
-Summary: Warewulf - HPC cluster configuration
 Name: warewulf-cluster
 Version: @PACKAGE_VERSION@
 Release: %{_rel}%{?dist}
+Summary: Warewulf - HPC cluster configuration
 License: US Dept. of Energy (BSD-like)
 URL: http://warewulf.lbl.gov/
 Source: %{name}-%{version}.tar.gz

--- a/common/warewulf-common.spec.in
+++ b/common/warewulf-common.spec.in
@@ -22,6 +22,7 @@
 
 %{!?_rel:%{expand:%%global _rel 0.%(test "@GITVERSION@" != "0000" && echo "@GITVERSION@" || git show -s --pretty=format:%h || echo 0000)}}
 %define debug_package %{nil}
+%{!?wwsrvdir:%{expand:%%define wwsrvdir %{_localstatedir}}}
 
 Name: warewulf-common
 Summary: Scalable systems management suite for high performance clusters
@@ -69,7 +70,8 @@ handlers and a basic command line interface.
 
 
 %build
-%configure
+WAREWULF_STATEDIR=%{wwsrvdir}
+%configure --localstatedir=%{wwsrvdir}
 %{__make} %{?mflags}
 
 

--- a/common/warewulf-common.spec.in
+++ b/common/warewulf-common.spec.in
@@ -25,10 +25,11 @@
 %{!?wwsrvdir:%{expand:%%define wwsrvdir %{_localstatedir}}}
 
 Name: warewulf-common
-Summary: Scalable systems management suite for high performance clusters
 Version: @PACKAGE_VERSION@
 Release: %{_rel}%{?dist}
+Summary: Scalable systems management suite for high performance clusters
 License: US Dept. of Energy (BSD-like)
+URL: http://warewulf.lbl.gov/
 Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
 Conflicts: warewulf < 3

--- a/ipmi/warewulf-ipmi.spec.in
+++ b/ipmi/warewulf-ipmi.spec.in
@@ -2,10 +2,10 @@
 %define debug_package %{nil}
 %{!?wwsrvdir:%{expand:%%define wwsrvdir %{_localstatedir}}}
 
-Summary: Warewulf - IPMI support
 Name: warewulf-ipmi
 Version: @PACKAGE_VERSION@
 Release: %{_rel}%{?dist}
+Summary: Warewulf - IPMI support
 License: US Dept. of Energy (BSD-like)
 URL: http://warewulf.lbl.gov/
 Source: %{name}-%{version}.tar.gz

--- a/ipmi/warewulf-ipmi.spec.in
+++ b/ipmi/warewulf-ipmi.spec.in
@@ -1,6 +1,6 @@
 %{!?_rel:%{expand:%%global _rel 0.%(test "@GITVERSION@" != "0000" && echo "@GITVERSION@" || git show -s --pretty=format:%h || echo 0000)}}
 %define debug_package %{nil}
-%{!?wwsrvdir:%{expand:%%define wwsrvdir %{_localstatedir}/warewulf}}
+%{!?wwsrvdir:%{expand:%%define wwsrvdir %{_localstatedir}}}
 
 Summary: Warewulf - IPMI support
 Name: warewulf-ipmi
@@ -21,7 +21,6 @@ Requires: ipmitool
 %define CONF_FLAGS "--with-local-ipmitool=yes"
 %else
 %global localipmi 0
-Provides: ipmitool = 1.8.18
 %endif
 
 BuildRequires: warewulf-common openssl-devel
@@ -41,7 +40,7 @@ cluster nodes.
 
 
 %build
-%configure %{?CONF_FLAGS}
+%configure --localstatedir=%{wwsrvdir} %{?CONF_FLAGS}
 %{__make} %{?mflags}
 
 
@@ -77,7 +76,7 @@ Warewulf IPMI-initramfs adds IPMI configuration to the %{_arch} cluster
 node boot image.
 
 %files initramfs-%{_arch}
-%{wwsrvdir}/initramfs/%{_arch}/capabilities/setup-ipmi
+%{wwsrvdir}/warewulf/initramfs/%{_arch}/capabilities/setup-ipmi
 
 
 # ====================

--- a/provision/warewulf-provision.spec.in
+++ b/provision/warewulf-provision.spec.in
@@ -3,10 +3,11 @@
 %{!?wwsrvdir:%{expand:%%define wwsrvdir %{_localstatedir}}}
 
 Name: warewulf-provision
-Summary: Warewulf - System provisioning core
 Version: @PACKAGE_VERSION@
 Release: %{_rel}%{?dist}
+Summary: Warewulf - System provisioning core
 License: US Dept. of Energy (BSD-like) and BSD-3 Clause
+URL: http://warewulf.lbl.gov/
 Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
 Requires: warewulf-common

--- a/provision/warewulf-provision.spec.in
+++ b/provision/warewulf-provision.spec.in
@@ -134,7 +134,7 @@ This package includes tools and files to create an initramfs
 image and to provide boot capability for %{_arch} architecture.
 
 %files initramfs-%{_arch}
-%{wwsrvdir}/initramfs/%{_arch}
+%{wwsrvdir}/warewulf/initramfs/%{_arch}
 
 
 # ====================
@@ -169,7 +169,7 @@ do not require this package.
 # Update users and services on first time installation
 if [ $1 -eq 1 ] ; then
 usermod -a -G warewulf %{httpgrp} >/dev/null 2>&1 || :
-%{__mkdir_p} %{wwsrvdir}/ipxe %{wwsrvdir}/bootstrap 2>/dev/null || :
+%{__mkdir_p} %{wwsrvdir}/warewulf/ipxe %{wwsrvdir}/warewulf/bootstrap 2>/dev/null || :
 %if 0%{?sle_version:1} || 0%{?rhel} >= 8
 %systemd_post %{httpdsvc}.service >/dev/null 2>&1 || :
 %systemd_post %{tftpsvc}.socket >/dev/null 2>&1 || :
@@ -184,7 +184,7 @@ fi
 # Reset selinux context on any installation or update
 /usr/sbin/semanage fcontext -a -t httpd_sys_content_t '%{wwsrvdir}/warewulf/ipxe(/.*)?' 2>/dev/null || :
 /usr/sbin/semanage fcontext -a -t httpd_sys_content_t '%{wwsrvdir}/warewulf/bootstrap(/.*)?' 2>/dev/null || :
-/sbin/restorecon -R %{wwsrvdir} || :
+/sbin/restorecon -R %{wwsrvdir}/warewulf || :
 
 
 %postun server

--- a/provision/warewulf-provision.spec.in
+++ b/provision/warewulf-provision.spec.in
@@ -1,6 +1,6 @@
 %{!?_rel:%{expand:%%global _rel 0.%(test "@GITVERSION@" != "0000" && echo "@GITVERSION@" || git show -s --pretty=format:%h || echo 0000)}}
 %define debug_package %{nil}
-%{!?wwsrvdir:%{expand:%%define wwsrvdir %{_localstatedir}/warewulf}}
+%{!?wwsrvdir:%{expand:%%define wwsrvdir %{_localstatedir}}}
 
 Name: warewulf-provision
 Summary: Warewulf - System provisioning core
@@ -82,7 +82,7 @@ administrate system provisioning.  To perform provisioning, the
 
 
 %build
-%configure %{?CONF_FLAGS} %{?CROSS_FLAG}
+%configure --localstatedir=%{wwsrvdir} %{?CONF_FLAGS} %{?CROSS_FLAG}
 %{__make} %{?mflags}
 
 
@@ -182,17 +182,17 @@ usermod -a -G warewulf %{httpgrp} >/dev/null 2>&1 || :
 fi
 
 # Reset selinux context on any installation or update
-/usr/sbin/semanage fcontext -a -t httpd_sys_content_t '%{wwsrvdir}/ipxe(/.*)?' 2>/dev/null || :
-/usr/sbin/semanage fcontext -a -t httpd_sys_content_t '%{wwsrvdir}/bootstrap(/.*)?' 2>/dev/null || :
+/usr/sbin/semanage fcontext -a -t httpd_sys_content_t '%{wwsrvdir}/warewulf/ipxe(/.*)?' 2>/dev/null || :
+/usr/sbin/semanage fcontext -a -t httpd_sys_content_t '%{wwsrvdir}/warewulf/bootstrap(/.*)?' 2>/dev/null || :
 /sbin/restorecon -R %{wwsrvdir} || :
 
 
 %postun server
 # Remove selinux context on package removal. Don't disable web or tftp services.
 if [ $1 -eq 0 ] ; then
-semanage fcontext -d -t httpd_sys_content_t '%{wwsrvdir}/ipxe(/.*)?' 2>/dev/null || :
+semanage fcontext -d -t httpd_sys_content_t '%{wwsrvdir}/warewulf/ipxe(/.*)?' 2>/dev/null || :
 semanage fcontext -d -t httpd_sys_content_t '%{wwsrvdir}/warewulf/bootstrap(/.*)?' 2>/dev/null || :
-/sbin/restorecon -R %{wwsrvdir} || :
+/sbin/restorecon -R %{wwsrvdir}/warewulf || :
 fi
 %if 0%{?sle_version:1} || 0%{?rhel} >= 8
 %systemd_postun_with_restart %{httpdsvc}.service >/dev/null 2>&1 || :

--- a/vnfs/warewulf-vnfs.spec.in
+++ b/vnfs/warewulf-vnfs.spec.in
@@ -1,5 +1,6 @@
 %{!?_rel:%{expand:%%global _rel 0.%(test "@GITVERSION@" != "0000" && echo "@GITVERSION@" || git show -s --pretty=format:%h || echo 0000)}}
 %define debug_package %{nil}
+%{!?wwsrvdir:%{expand:%%define wwsrvdir %{_localstatedir}}}
 
 Summary: Warewulf - Virtual Node File System support
 Name: warewulf-vnfs
@@ -31,7 +32,7 @@ node operating systems.
 
 
 %build
-%configure
+%configure --localstatedir=%{wwsrvdir}
 %{__make} %{?mflags}
 
 

--- a/vnfs/warewulf-vnfs.spec.in
+++ b/vnfs/warewulf-vnfs.spec.in
@@ -2,10 +2,10 @@
 %define debug_package %{nil}
 %{!?wwsrvdir:%{expand:%%define wwsrvdir %{_localstatedir}}}
 
-Summary: Warewulf - Virtual Node File System support
 Name: warewulf-vnfs
 Version: @PACKAGE_VERSION@
 Release: %{_rel}%{?dist}
+Summary: Warewulf - Virtual Node File System support
 License: US Dept. of Energy (BSD-like)
 URL: http://warewulf.lbl.gov/
 Source: %{name}-%{version}.tar.gz


### PR DESCRIPTION
Updates the specfiles to correctly implement using a different service file directory (still defaults to /var). This is required for OpenHPC.

Cleaned up tags to put them in the same order and added missing URL tags.

Removed the Provides for ipmitool, since the tool is installed in a WW subdirectory. Provides for e2fsprogs, parted, are libarchive are still included, as those tools are installed in regular OS locations.

Fixed the Description wording, as requested in a previous PR.