### PR TITLE
updated capabilities so that you can have fstab in provision files

### DIFF
--- a/provision/initramfs/capabilities/provision-vnfs/50-config
+++ b/provision/initramfs/capabilities/provision-vnfs/50-config
@@ -39,5 +39,6 @@ if [ -z "${WWNOFSTABUPDATE}" ]; then
     else
         cp -f /tmp/fstab "${NEWROOT}/etc/fstab"
     fi
+    cp /tmp/fstab "${NEWROOT}/etc/fstab.ww.generated_entries"
 fi
 

--- a/provision/initramfs/capabilities/transport-http/wwgetfiles
+++ b/provision/initramfs/capabilities/transport-http/wwgetfiles
@@ -97,6 +97,9 @@ while true; do
                         else
                             chmod $mode "$NEWROOT/$path.ww$timestamp"
                         fi
+                        if [ -z "${WWNOFSTABUPDATE}" -a "$path" = "/etc/fstab" -a -f "$NEWROOT/etc/fstab.ww.generated_entries" ]; then
+                            sed -i "/#GENERATED_ENTRIES#/r $NEWROOT/etc/fstab.ww.generated_entries" "$NEWROOT/$path.ww$timestamp"
+                        fi
                         mv "$NEWROOT/$path.ww$timestamp" "$NEWROOT/$path"
                         chown $uid "$NEWROOT/$path"
                         chgrp $gid "$NEWROOT/$path"


### PR DESCRIPTION
Hello,

i had to provision some nodes with different fstab so i added fstab as a provision file,
i encountered the problem that the entry generated by provision/fs (like swap) are only added in the fstab in the chroot and i loose them if i provision the file,
my solution was to:

1. modify `50-config` so that it saves the generated entries in /etc/fstab.ww.generated_entries
2. modify `wwgetfiles` so that if the file path is /etc/fstab and i find in the file the line `#GENERATED_ENTRIES#` i put below this line the generated entries taken from /etc/fstab.ww.generated_entries

This worked fine for me, i used the variable `${WWNOFSTABUPDATE}` because it was already in place before.

Waiting for feedback.