### PR TITLE
Untaint $path earlier.

### DIFF
--- a/common/lib/Warewulf/File.pm
+++ b/common/lib/Warewulf/File.pm
@@ -494,7 +494,7 @@ file_import()
     if ($path =~ /^(\/.+)$/) {
         $path = $1;
     } else {
-        &eprint("Import filename contains illegal characters.\n");
+        &eprint("Filename must be an absolute path.\n");
         return undef;
     }
 

--- a/common/lib/Warewulf/Module/Cli/File.pm
+++ b/common/lib/Warewulf/Module/Cli/File.pm
@@ -294,7 +294,7 @@ exec()
             if ($path =~ /^(\/.+)$/) {
                 $path = $1;
             } else {
-                &eprint("Import filename contains illegal characters.\n");
+                &eprint("Filename must be an absolute path.\n");
                 return undef;
             }
 

--- a/common/lib/Warewulf/Module/Cli/File.pm
+++ b/common/lib/Warewulf/Module/Cli/File.pm
@@ -291,6 +291,13 @@ exec()
 
             my $path = abs_path($path);
 
+            if ($path =~ /^(\/.+)$/) {
+                $path = $1;
+            } else {
+                &eprint("Import filename contains illegal characters.\n");
+                return undef;
+            }
+
             @statinfo = lstat($path);
             if (-e _) {
                 my ($mode, $uid, $gid) = @statinfo[(2, 4, 5)];


### PR DESCRIPTION
Needed in the case that a file actually doesn't exist. Issue reported
by Ric Anderson on OpenHPC list.