### PR TITLE
Fixed wwmkchroot -g nogpgcheck option problems

### DIFF
--- a/vnfs/libexec/wwmkchroot/include-rhel
+++ b/vnfs/libexec/wwmkchroot/include-rhel
@@ -110,9 +110,9 @@ prechroot() {
     rm -f $CHROOTDIR/etc/yum.repos.d/*
     
     # Create new repos from comma-seperated list (using bash inline S&R)
-    [ "0$REPO_NOGPGCECK" -ne "00" ] && REPO_NOGPGCHECK=1
+    if [ "0$NOGPGCHECK" -eq "00" ]; then REPO_NOGPGCHECK=0; else REPO_NOGPGCHECK=1; fi
     for i in ${YUM_MIRROR//,/ }; do
-        $YUM_REPOCMD --add-repo --setopt=gpgcheck=$REPO_NOGPGCHECK $i 
+        $YUM_REPOCMD --setopt=gpgcheck=$REPO_NOGPGCHECK --add-repo $i
     done
 
     PKGR_CMD="$YUM_CMD install $PKGLIST"


### PR DESCRIPTION
This patch fixed the following three problems:

1. '"0$REPO_NOGPGCECK"' had two typos, 'REPO_' is unnecessary and
   'CECK' should be "CHECK", so it should be '"0$NOGPGCHECK"'.
2. '--setopt=gpgcheck=' with empty parameter caused error, so
   '$REPO_NOGPGCHECK' has to be either '0' or '1'
3. Inserted '--setopt=gpgcheck=$REPO_NOGPGCHECK' between '--add-repo'
   and '$i' caused '--add-repo' parameter error, so it should be
   '--setopt=gpgcheck=$REPO_NOGPGCHECK --add-repo $i'.

Signed-off-by: Naohiro Tamura <naohirot@jp.fujitsu.com>