### PR TITLE
Fix: missing ' 0' in the end of efi*example.cmds

### DIFF
--- a/provision/etc/filesystem/examples/efi_example.cmds
+++ b/provision/etc/filesystem/examples/efi_example.cmds
@@ -19,4 +19,4 @@ mkfs 3 ext4 -L root
 # fstab NUMBER fs_file fs_vfstype fs_mntops fs_freq fs_passno
 fstab 3 / ext4 defaults 0 0
 fstab 1 /boot/efi vfat defaults 0 0
-fstab 2 swap swap defaults 0
+fstab 2 swap swap defaults 0 0

--- a/provision/etc/filesystem/examples/efi_nvme_example.cmds
+++ b/provision/etc/filesystem/examples/efi_nvme_example.cmds
@@ -23,4 +23,4 @@ mkfs p3 ext4 -L root
 # fstab NUMBER fs_file fs_vfstype fs_mntops fs_freq fs_passno
 fstab p3 / ext4 defaults 0 0
 fstab p1 /boot/efi vfat defaults 0 0
-fstab p2 swap swap defaults 0
+fstab p2 swap swap defaults 0 0


### PR DESCRIPTION
The last line of provision/etc/filesystem/examples/efi_example.cmds and
provision/etc/filesystem/examples/efi_nvme_example.cmds seems not
complete.  Add the missing ' 0' to correct it.

Signed-off-by: Yang Jian <yangj.fnst@cn.fujitsu.com>