### PR TITLE
Fixed grub2-install error "efibootmgr not found" in UEFI stateful pro…

### DIFF
--- a/provision/initramfs/capabilities/setup-filesystems/80-mkbootable
+++ b/provision/initramfs/capabilities/setup-filesystems/80-mkbootable
@@ -271,7 +271,7 @@ dev_symlinks() {
       echo "grub-mkconfig failed."
       exit 2
     fi 
-    if chroot "${NEWROOT}" "${GRUBINSTALL}" "${BOOTLOADER}" >/dev/null; then
+    if chroot "${NEWROOT}" /bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${GRUBINSTALL}" "${BOOTLOADER}" >/dev/null; then
        exit 0
     else
       echo "grub-install failed."


### PR DESCRIPTION
…visioning

/usr/sbin/grub2-install cannot invoke efibootmgr which is installed in
/usr/sbin of the chroot /newroot filesystem, because PATH environment
variable doesn't contain /usr/sbin but only /usr/local/bin:/usr/bin as
shown below:

 > / # cat /var/log/warewulf/provision/mkbootable.log
 > ...
 > + chroot /newroot /usr/sbin/grub2-install /dev/sda
 > Installing for x86_64-efi platform.
 > /usr/sbin/grub2-install: error: efibootmgr: not found.
 > + echo grub-install failed.
 > + exit 2
 > / # echo $PATH
 > /sbin:/usr/sbin:/bin:/usr/bin
 > / # chroot /newroot
 > bash-4.4# echo $PATH
 > /usr/local/bin:/usr/bin

This patch fixed PATH environment variable of the chroot /newroot
environment.

Signed-off-by: Naohiro Tamura <naohirot@jp.fujitsu.com>