### PR TITLE
Make NEWROOT early in init

### DIFF
--- a/provision/initramfs/init
+++ b/provision/initramfs/init
@@ -25,6 +25,9 @@ mount -t sysfs none /sys >/dev/null 2>&1
 NEWROOT=/newroot
 export NEWROOT
 
+# Make this... now.
+mkdir -p ${NEWROOT}
+
 # Old habits die hard.
 DESTDIR=$NEWROOT
 export DESTDIR


### PR DESCRIPTION
Make sure the value of NEWROOT is created early in the /init process.