### PR TITLE
Added OpenSUSE Leap 15.1 aarch64 repository

### DIFF
--- a/vnfs/libexec/wwmkchroot/opensuse-15.1.tmpl
+++ b/vnfs/libexec/wwmkchroot/opensuse-15.1.tmpl
@@ -11,11 +11,19 @@
 # REPO_NOGPGHECK=1
 
 # Comma-seperated location(s) of the YUM repositories
-ZYPP_MIRROR="http://download.opensuse.org/distribution/leap/15.1/repo/oss/,\
+if [ "$(uname -m)" = "x86_64" ]; then
+    ZYPP_MIRROR="http://download.opensuse.org/distribution/leap/15.1/repo/oss/,\
 http://download.opensuse.org/update/leap/15.1/oss/"
-# URLs for OpenSUSE LEAP 15.0
-#ZYPP_MIRROR="http://download.opensuse.org/distribution/leap/15.1/repo/oss/,\
+    # URLs for OpenSUSE LEAP 15.0
+    #ZYPP_MIRROR="http://download.opensuse.org/distribution/leap/15.0/repo/oss/,\
 #http://download.opensuse.org/update/leap/15.0/oss/"
+elif [ "$(uname -m)" = "aarch64" ]; then
+    ZYPP_MIRROR="http://download.opensuse.org/ports/aarch64/distribution/leap/15.1/repo/oss/,\
+http://download.opensuse.org/ports/aarch64/update/leap/15.1/oss/"
+else
+    echo "Unsupported Architecture"
+    exit 1
+fi
 
 # Install only what is necessary/specific for this distribution
 PKGLIST="systemd-sysvinit aaa_base bash dracut openSUSE-release coreutils \


### PR DESCRIPTION
This patch added OpenSUSE Leap 15.1 aarch64 repository which is
different from x86_64 repository.

Signed-off-by: Naohiro Tamura <naohirot@jp.fujitsu.com>