### PR TITLE
Add support for dhcp shared networks

### DIFF
--- a/provision/etc/provision.conf
+++ b/provision/etc/provision.conf
@@ -14,12 +14,14 @@ network device = eth1
 # select between 'isc' or 'dnsmasq'
 dhcp server = isc
 
-# Enable support for shared dhcp subnet blocks.
-# By default warewulf expects to share one flat network
-# If your SMS node is on a different subnet than
-# your compute nodes set this to shared.
-# Acceptable values are "shared" or "flat"
-dhcp network = flat
+# How should the DHCP subnet(s) be established?
+# direct - Only generate DHCP host reservations for nodes within the 
+# same subnet as the configured 'network device' or 
+# 'ip address' (default)
+# relay - Generate DHCP host reservations for all nodes in the 
+# Warewulf database without regard to subnet. Useful for DHCP relay 
+# configurations.
+dhcp network = direct
 
 
 # What is the TFTP root directory that should be used to store the

--- a/provision/etc/provision.conf
+++ b/provision/etc/provision.conf
@@ -14,6 +14,14 @@ network device = eth1
 # select between 'isc' or 'dnsmasq'
 dhcp server = isc
 
+# Enable support for shared dhcp subnet blocks.
+# By default warewulf expects to share one flat network
+# If your SMS node is on a different subnet than
+# your compute nodes set this to shared.
+# Acceptable values are "shared" or "flat"
+dhcp network = flat
+
+
 # What is the TFTP root directory that should be used to store the
 # network boot images? By default Warewulf will try and find the
 # proper directory. Just add this if it can't locate it.

--- a/provision/lib/Warewulf/Provision/Dhcp/Isc.pm
+++ b/provision/lib/Warewulf/Provision/Dhcp/Isc.pm
@@ -152,7 +152,7 @@ persist()
     my $ipaddr = $config->get("ip address") // $netobj->ipaddr($devname);
     my $netmask = $config->get("ip netmask") // $netobj->netmask($devname);
     my $network = $config->get("ip network") // $netobj->network($devname);
-    my $dhcp_net = $config->get("dhcp network") || "flat";
+    my $dhcp_net = $config->get("dhcp network") || "direct";
     my $config_template;
     my $dhcpd_contents;
     my %seen;
@@ -284,7 +284,7 @@ persist()
                     next;
                 }
 
-                if (($dhcp_net eq "flat") and ($node_testnetwork ne $network)) {
+                if (($dhcp_net eq "direct") and ($node_testnetwork ne $network)) {
                     &iprint("Skipping DHCP config for $nodename-$devname (on a different network)\n");
                     $dhcpd_contents .= "   # Skipping $nodename-$devname: Not on boot network ($node_testnetwork)\n";
                     next;

--- a/provision/lib/Warewulf/Provision/Dhcp/Isc.pm
+++ b/provision/lib/Warewulf/Provision/Dhcp/Isc.pm
@@ -152,6 +152,7 @@ persist()
     my $ipaddr = $config->get("ip address") // $netobj->ipaddr($devname);
     my $netmask = $config->get("ip netmask") // $netobj->netmask($devname);
     my $network = $config->get("ip network") // $netobj->network($devname);
+    my $dhcp_net = $config->get("dhcp network") || "flat";
     my $config_template;
     my $dhcpd_contents;
     my %seen;
@@ -283,7 +284,7 @@ persist()
                     next;
                 }
 
-                if ($node_testnetwork ne $network) {
+                if (($dhcp_net eq "flat") and ($node_testnetwork ne $network)) {
                     &iprint("Skipping DHCP config for $nodename-$devname (on a different network)\n");
                     $dhcpd_contents .= "   # Skipping $nodename-$devname: Not on boot network ($node_testnetwork)\n";
                     next;

--- a/provision/lib/Warewulf/Provision/HostsFile.pm
+++ b/provision/lib/Warewulf/Provision/HostsFile.pm
@@ -96,7 +96,7 @@ generate()
     my $master_ipaddr = $config->get("ip address") // $netobj->ipaddr($netdev);
     my $master_network = $config->get("ip network") // $netobj->network($netdev);
     my $master_netmask = $config->get("ip netmask") // $netobj->netmask($netdev);
-    my $dhcp_net = $config->get("dhcp network") || "flat";
+    my $dhcp_net = $config->get("dhcp network") || "direct";
 
     if (! $master_ipaddr or ! $master_netmask or ! $master_network) {
         &wprint("Could not generate hostfile, check 'network device' or 'ip address/netmask/network' configuration!\n");
@@ -159,7 +159,7 @@ generate()
             }
 
             &dprint("Checking to see if node is on same network as master: $node_testnetwork ?= $master_network\n");
-            if ($devcount == 1 or (($dhcp_net eq "flat") and ($node_testnetwork eq $master_network) and ! defined($default_name))) {
+            if ($devcount == 1 or (($dhcp_net eq "direct") and ($node_testnetwork eq $master_network) and ! defined($default_name))) {
                 &dprint("Using $nodename-$devname as default\n");
                 $default_name = 1;
                 $n->nodename($nodename);

--- a/provision/lib/Warewulf/Provision/HostsFile.pm
+++ b/provision/lib/Warewulf/Provision/HostsFile.pm
@@ -96,6 +96,7 @@ generate()
     my $master_ipaddr = $config->get("ip address") // $netobj->ipaddr($netdev);
     my $master_network = $config->get("ip network") // $netobj->network($netdev);
     my $master_netmask = $config->get("ip netmask") // $netobj->netmask($netdev);
+    my $dhcp_net = $config->get("dhcp network") || "flat";
 
     if (! $master_ipaddr or ! $master_netmask or ! $master_network) {
         &wprint("Could not generate hostfile, check 'network device' or 'ip address/netmask/network' configuration!\n");
@@ -158,7 +159,7 @@ generate()
             }
 
             &dprint("Checking to see if node is on same network as master: $node_testnetwork ?= $master_network\n");
-            if ($devcount == 1 or (($node_testnetwork eq $master_network) and ! defined($default_name))) {
+            if ($devcount == 1 or (($dhcp_net eq "flat") and ($node_testnetwork eq $master_network) and ! defined($default_name))) {
                 &dprint("Using $nodename-$devname as default\n");
                 $default_name = 1;
                 $n->nodename($nodename);

--- a/provision/lib/Warewulf/Provision/Pxe.pm
+++ b/provision/lib/Warewulf/Provision/Pxe.pm
@@ -139,6 +139,7 @@ update()
     my $master_ipaddr = $config->get("ip address") // $netobj->ipaddr($devname);
     my $master_network = $config->get("ip network") // $netobj->network($devname);
     my $master_netmask = $config->get("ip netmask") // $netobj->netmask($devname);
+    my $dhcp_net = $config->get("dhcp network") || "flat";
 
     if (! $master_ipaddr) {
         &wprint("Could not generate PXE configurations, check 'network device' or 'ip address/netmask/network' configuration!\n");
@@ -238,7 +239,7 @@ update()
                 next;
             }
 
-            if ($node_ipaddr and $node_testnetwork ne $master_network) {
+            if (($dhcp_net eq "flat") and $node_ipaddr and $node_testnetwork ne $master_network) {
                 &iprint("Skipping PXE config for $nodename-$devname (on a different network)\n");
                 next;
             }

--- a/provision/lib/Warewulf/Provision/Pxe.pm
+++ b/provision/lib/Warewulf/Provision/Pxe.pm
@@ -139,7 +139,7 @@ update()
     my $master_ipaddr = $config->get("ip address") // $netobj->ipaddr($devname);
     my $master_network = $config->get("ip network") // $netobj->network($devname);
     my $master_netmask = $config->get("ip netmask") // $netobj->netmask($devname);
-    my $dhcp_net = $config->get("dhcp network") || "flat";
+    my $dhcp_net = $config->get("dhcp network") || "direct";
 
     if (! $master_ipaddr) {
         &wprint("Could not generate PXE configurations, check 'network device' or 'ip address/netmask/network' configuration!\n");
@@ -239,7 +239,7 @@ update()
                 next;
             }
 
-            if (($dhcp_net eq "flat") and $node_ipaddr and $node_testnetwork ne $master_network) {
+            if (($dhcp_net eq "direct") and $node_ipaddr and $node_testnetwork ne $master_network) {
                 &iprint("Skipping PXE config for $nodename-$devname (on a different network)\n");
                 next;
             }


### PR DESCRIPTION
Rebase #236  against upstream development branch

Our use case is that each rack in our cluster is a separate /26 using dhcp helper to forward requests to an off cluster ohpc management node. The purpose of the network cuts is to facilitate a smoother transition to ohpc 2.0 when it becomes available that doesn't require taking the entire cluster offline at once. The patch is based on this thread https://groups.google.com/a/lbl.gov/forum/#!topic/warewulf/Yx9OMqkyJKU and it adds a configuration directive "dhcp network = shared" to enable the behavior, otherwise it reverts to the default behavior.