### PR TITLE
Fix error on clone

### DIFF
--- a/provision/lib/Warewulf/Event/DefaultProvisionNode.pm
+++ b/provision/lib/Warewulf/Event/DefaultProvisionNode.pm
@@ -64,6 +64,9 @@ default_provision_node()
             if (! $obj->fileids()) {
                 $obj->fileids(@fileids);
             } else {
+                # Remove any files referenced in defaults/provision.conf first
+                # incase we're a cloned node
+                $obj->fileiddel(@fileids);
                 $obj->fileidadd(@fileids);
             }
         }


### PR DESCRIPTION
When cloning, you can get a "duplicate entry for key 'object_id'" error.
This comes from `DefaultProvisionNode.pm` blindly adding fileid's from
defaults/provision.conf to a node when they already exist.

Remove those file ID's before trying to add them back to the node
object.

Fixes #245