### PR TITLE
provision: Add support for restrictive umask

### DIFF
--- a/provision/lib/Warewulf/Bootstrap.pm
+++ b/provision/lib/Warewulf/Bootstrap.pm
@@ -15,7 +15,7 @@ use Warewulf::Logger;
 use Warewulf::DataStore;
 use Warewulf::Util;
 use File::Basename;
-use File::Path;
+use File::Path qw(make_path);
 use Digest::MD5 qw(md5_hex);
 use POSIX qw(uname);
 
@@ -211,6 +211,9 @@ bootstrap_export()
 
             if (! -d $dirname) {
                 mkpath($dirname);
+                make_path($dirname, {
+                    chmod => 0755,
+                });
             }
         }
 
@@ -350,7 +353,9 @@ build_local_bootstrap()
             }
 
             mkpath($tmpdir);
-            mkpath($bootstrapdir);
+            make_path($bootstrapdir, {
+                chmod => 0755,
+            });
             chdir($tmpdir);
 
             &dprint("Opening gunzip/cpio pipe\n");
@@ -381,10 +386,13 @@ build_local_bootstrap()
             system("cd $tmpdir/initramfs; find . | cpio -o --quiet -H newc -F $bootstrapdir/initfs");
             &nprint("Compressing the initramfs\n");
             system("gzip -f -9 $bootstrapdir/initfs");
+            chmod(0644, "$bootstrapdir/initfs.gz");
             &nprint("Locating the kernel object\n");
             system("cp $tmpdir/kernel $bootstrapdir/kernel");
+            chmod(0644, "$bootstrapdir/kernel");
             system("rm -rf $tmpdir");
             open(COOKIE, "> $bootstrapdir/cookie");
+            chmod(0644, "$bootstrapdir/cookie");
             print COOKIE $self->checksum();
             close COOKIE;
             &nprint("Bootstrap image '$bootstrap_name' is ready\n");

--- a/provision/lib/Warewulf/Provision/Pxe.pm
+++ b/provision/lib/Warewulf/Provision/Pxe.pm
@@ -18,7 +18,7 @@ use Warewulf::Network;
 use Warewulf::DataStore;
 use Warewulf::Provision::Tftp;
 use File::Basename;
-use File::Path;
+use File::Path qw(make_path);
 use POSIX qw(uname);
 
 our @ISA = ('Warewulf::Object');
@@ -94,8 +94,11 @@ setup()
                 if (-f "$datadir/warewulf/ipxe/$f") {
                     &iprint("Copying $f to the tftp root\n");
                     my $dirname = dirname("$tftpdir/warewulf/ipxe/$f");
-                    mkpath($dirname);
+                    make_path($dirname, {
+                        chmod => 0755,
+                    });
                     system("cp $datadir/warewulf/ipxe/$f $tftpdir/warewulf/ipxe/$f");
+                    chmod(0644, "$tftpdir/warewulf/ipxe/$f");
                 } elsif ($arch eq "x86_64") {
                     &eprint("Could not locate Warewulf's internal $datadir/warewulf/ipxe/$f! Things might be broken!\n");
                 }
@@ -106,8 +109,11 @@ setup()
                 if (-f "$datadir/warewulf/ipxe/$f") {
                     &iprint("Copying $f to the tftp root\n");
                     my $dirname = dirname("$tftpdir/warewulf/ipxe/$f");
-                    mkpath($dirname);
+                    make_path($dirname, {
+                        chmod => 0755,
+                    });
                     system("cp $datadir/warewulf/ipxe/$f $tftpdir/warewulf/ipxe/$f");
+                    chmod(0644, "$tftpdir/warewulf/ipxe/$f");
                 } elsif ($arch eq "aarch64") {
                     &eprint("Could not locate Warewulf's internal $datadir/warewulf/ipxe/$f! Things might be broken!\n");
                 }
@@ -155,7 +161,9 @@ update()
 
     if (! -d "$statedir/warewulf/ipxe/cfg") {
         &iprint("Creating ipxe configuration directory: $statedir/warewulf/ipxe/cfg");
-        mkpath("$statedir/warewulf/ipxe/cfg");
+        make_path("$statedir/warewulf/ipxe/cfg", {
+            chmod => 0755,
+        });
     }
 
     foreach my $nodeobj (@nodeobjs) {
@@ -323,6 +331,7 @@ update()
                     if (! close IPXE) {
                         &eprint("Could not write iPXE configuration file: $!\n");
                     }
+		    chmod(0644, "$statedir/warewulf/ipxe/cfg/$config");
                 } else {
                     &eprint("Node: $nodename-$devname: Bad characters in hwaddr: '$hwaddr'\n");
                 }
@@ -372,6 +381,9 @@ delete()
                 &iprint("Deleting PXE configuration for $nodename/$config\n");
                 if (-f "$statedir/warewulf/ipxe/cfg/$config") {
                     unlink("$statedir/warewulf/ipxe/cfg/$config");
+                }
+                if (! chmod 0644, "$statedir/warewulf/ipxe/cfg/$config") {
+                    &eprint("Could not chmod Pxelinux configuration file: $!\n");
                 }
             } else {
                 &eprint("Bad characters in hwaddr: $hwaddr\n");


### PR DESCRIPTION
These changes are required to get pxeboot working when a restrictive
umask (in my case it was 0077) is in place. Ran into this issue when
trying to get OpenHPC installed.

Signed-off-by: Sol Jerome <solj@utdallas.edu>