### PR TITLE
Replace /etc/os-release in chroot with RPM version

### DIFF
--- a/vnfs/libexec/wwmkchroot/include-rhel
+++ b/vnfs/libexec/wwmkchroot/include-rhel
@@ -124,8 +124,8 @@ postchroot() {
 
     # If /etc/os-release.rpmnew exists, make it the real /etc/os-release
     if [ -f $CHROOTDIR/etc/os-release.rpmnew ]; then
-        mv /etc/os-release /etc/os-release.warewulf
-        mv /etc/os-release.rpmnew /etc/os-release
+        mv $CHROOTDIR/etc/os-release $CHROOTDIR/etc/os-release.warewulf
+        mv $CHROOTDIR/etc/os-release.rpmnew $CHROOTDIR/etc/os-release
     fi
 
     # we only want to add this kludge to the file once. lets make sure an

--- a/vnfs/libexec/wwmkchroot/include-rhel
+++ b/vnfs/libexec/wwmkchroot/include-rhel
@@ -122,6 +122,12 @@ prechroot() {
 postchroot() {
     touch $CHROOTDIR/fastboot
 
+    # If /etc/os-release.rpmnew exists, make it the real /etc/os-release
+    if [ -f $CHROOTDIR/etc/os-release.rpmnew ]; then
+        mv /etc/os-release /etc/os-release.warewulf
+        mv /etc/os-release.rpmnew /etc/os-release
+    fi
+
     # we only want to add this kludge to the file once. lets make sure an
     # improperly writen overlay template wont cause repeated file concatenation
     # network-functions is not present on RHEL 8


### PR DESCRIPTION
We create a minimal /etc/os-release file in the chroot to be able to build the chroot image. When an RPM package is installed, this file is seen, so the real /etc/os-release is written out as /etc/os-release.rpmnew ...

Make sure the RPM os-release is what we use.
