### PR TITLE
Clarify meaning of "Signed-off-by" explanation.

### DIFF
--- a/provision/3rd_party/GPL/README
+++ b/provision/3rd_party/GPL/README
@@ -10,7 +10,8 @@ must be respected and followed when redistributing Warewulf packages.
 
 The Warewulf developers on behalf of Lawrence Berkeley National Laboratory
 have contacted the upstream maintainers of these projects and notified them
-of our intentions.
+of our intentions. The Warewulf project will include binaries along with 
+the sources where necessary as explained above for the projects listed below.
 
 
 Signed-off-by:


### PR DESCRIPTION
The "signed-off-by" block does not make it clear what has been signed off by the listed project developers. This addition adds a sentence to make this explanation clearer.