### PR TITLE
Add support for the IPMI target parameter

### DIFF
--- a/ipmi/lib/Warewulf/Ipmi.pm
+++ b/ipmi/lib/Warewulf/Ipmi.pm
@@ -222,6 +222,23 @@ ipmi_autoconfig()
     return $self->get($key);
 }
 
+=item ipmi_target($string)
+
+Set IPMI target (-t <target>).  This paramter is usually used by IPMI
+chassis that control multiple systems.  In most implementations this option
+is not necessary.  Target should be in hex form (e.g. 0x04), or 'UNDEF' to
+disable.
+
+=cut
+
+sub
+ipmi_target()
+{
+    $self = shift;
+
+    return $self->prop("ipmi_target", qr/^(0x[0-9a-fA-F][0-9a-fA-F])$/, @_);
+}
+
 
 =item ipmi_command($action)
 
@@ -255,6 +272,7 @@ ipmi_command()
     my $username = $self->ipmi_username();
     my $password = $self->ipmi_password();
     my $proto = $self->ipmi_proto();
+    my $target = $self->ipmi_target() || "UNDEF";
     my $name = $self->name() || "UNDEF";
     my $libexecdir = Warewulf::ACVars->libexecdir();
     my $ret;
@@ -266,6 +284,9 @@ ipmi_command()
     }
     if ($ipaddr and $username and $password and $proto) {
         $ret .= "-I $proto -U $username -P $password -H $ipaddr ";
+        if ($target ne "UNDEF") {
+            $ret .= "-t $target ";
+        }
         if ($action eq "poweron" ) {
             $ret .= "chassis power on";
         } elsif ( $action eq "poweroff" ) {

--- a/ipmi/lib/Warewulf/Module/Cli/Ipmi.pm
+++ b/ipmi/lib/Warewulf/Module/Cli/Ipmi.pm
@@ -111,6 +111,7 @@ help()
     $h .= "         --username      Define the IPMI username for this node\n";
     $h .= "         --password      Define the IPMI password for this node\n";
     $h .= "         --proto         Define the IPMI protocol for this node (defaults to lan)\n";
+    $h .= "         --target        Define the IPMI target (for multi-node chassis)\n";
     $h .= "         --autoconfig    Automatically try and configure this node's IPMI settings\n";
     $h .= "                         on boot (boolean 1/0) - note: if no password is set for the\n";
     $h .= "                         node, one will be randomly generated\n";
@@ -221,6 +222,7 @@ exec()
         'd|delay=s'     => \$opt_padding,
         'p|padding=s'   => \$opt_padding,
         'f|fanout=s'    => \$opt_fanout,
+       'target=s'      => \$opt_target,
     );
 
     $command = shift(@ARGV);
@@ -365,6 +367,21 @@ exec()
                 $persist_bool = 1;
             } else {
                 print "IPMI protocol $opt_proto is not supported.\n";
+            }
+        }
+        if ($opt_target) {
+            if (uc($opt_target) eq "UNDEF") {
+                foreach my $o ($objSet->get_list()) {
+                    $o->ipmi_target(undef);
+                }
+                push(@changes, sprintf("   UNDEF: %-20s\n", "IPMI_TARGET"));
+                $persist_bool = 1;
+            } else {
+                foreach my $o ($objSet->get_list()) {
+                    $o->ipmi_target($opt_target);
+                }
+                push(@changes, sprintf("     SET: %-20s = %s\n", "IPMI_TARGET", $opt_target));
+                $persist_bool = 1;
             }
         }
         if (defined($opt_autoconfig)) {
@@ -653,6 +670,7 @@ exec()
             printf("%15s: %-16s = %s\n", $name, "IPMI_PASSWORD", $o->get("ipmi_password") || "UNDEF");
             printf("%15s: %-16s = %s\n", $name, "IPMI_AUTOCONFIG", $o->get("ipmi_autoconfig") || "UNDEF");
             printf("%15s: %-16s = %s\n", $name, "IPMI_PROTO", $o->ipmi_proto() || "UNDEF");
+            printf("%15s: %-16s = %s\n", $name, "IPMI_TARGET", $o->ipmi_target() || "UNDEF");
         }
 
     } elsif ($command eq "list") {


### PR DESCRIPTION
This patch adds the ability to specify an IPMI target (`ipmitool -t <target>`).  Though not extremely common, this is used on certain chassis with central controllers to specify IPMI control over a specific node.  An example is the HPE Apollo 80 chassis.