### PR TITLE
Use a more flexible regexp to check for valid console devices

### DIFF
--- a/provision/lib/Warewulf/Module/Cli/Provision.pm
+++ b/provision/lib/Warewulf/Module/Cli/Provision.pm
@@ -609,7 +609,7 @@ exec()
         }
 
         if ($opt_console) {
-            if ($opt_console =~ /^(tty[S0-9]+\,[0-9]+)/ || $opt_console =~ /^(UNDEF)$/) {
+            if ($opt_console =~ /^((tty|lp)[A-Z]*[0-9]+(,[0-9]{4,6}([noe]([0-9]r?)?)?)?)/ || $opt_console =~ /^(UNDEF)$/) {
                 $opt_console = $1;
 
                 foreach my $obj ($objSet->get_list()) {


### PR DESCRIPTION
Currently, warewulf uses a regex in the Cli to check if a console device is valid, but that regex is too restrictive for some systems.  It limits specification to `tty[S0-9]+\,[0-9]+`.  A couple of examples of valid devices that this doesn't allow include: `ttyUSB0` (usb-serial console), and `ttyAMA0` (default BMC console for many ARM-based systems).  Additionally, while it allows for the specification of rate, it doesn't allow for the specification of parity, stop bits, or flow control.

This is a one-line fix that uses: `(tty|lp)[A-Z]*[0-9]+(,[0-9]{4,6}([noe]([0-9]r?)?)?)?`  to match console devices.  This approximately matches the kernel documentation, with the added information that in general, consoles of the form `tty[A-Z]*[0-9]+` have become common.

Of course, another option would be to simply not try to validate this bit of input.

From the kernel docs:
```
console=device,options

device:         tty0 for the foreground virtual console
                ttyX for any other virtual console
                ttySx for a serial port
                lp0 for the first parallel port
                ttyUSB0 for the first USB serial device

options:        depend on the driver. For the serial port this
                defines the baudrate/parity/bits/flow control of
                the port, in the format BBBBPNF, where BBBB is the
                speed, P is parity (n/o/e), N is number of bits,
                and F is flow control ('r' for RTS). Default is
                9600n8. The maximum baudrate is 115200.
```