### PR TITLE
Add nfs-utils as requirement for cluster RPM and tcpdump for provision-server RPM for wwnodescan

### DIFF
--- a/cluster/warewulf-cluster.spec.in
+++ b/cluster/warewulf-cluster.spec.in
@@ -11,6 +11,7 @@ URL: http://warewulf.lbl.gov/
 Source: %{name}-%{version}.tar.gz
 ExclusiveOS: linux
 Requires: warewulf-common, warewulf-provision
+Requires: nfs-utils
 BuildRequires: warewulf-common
 Conflicts: warewulf < 3
 

--- a/provision/warewulf-provision.spec.in
+++ b/provision/warewulf-provision.spec.in
@@ -145,7 +145,7 @@ image and to provide boot capability for %{_arch} architecture.
 Summary: Warewulf - System provisioning server
 Requires: %{name} = %{version}-%{release}
 Requires: %{name}-server-ipxe-%{_arch} = %{version}-%{release}
-Requires: %{httpsvc}, perl(Apache), %{tftpsvc}, %{dhcpsrv}
+Requires: %{httpsvc}, perl(Apache), %{tftpsvc}, %{dhcpsrv}, tcpdump
 
 %if 0%{?rhel} >= 8
 Requires(post): policycoreutils-python-utils


### PR DESCRIPTION
Based on @gmkurtzer's https://github.com/warewulf/warewulf3/pull/262/commits/fb54c4962322bbd21c4ae0e15a3e332bb72de9e7.

Should make the NFS wwinit succeed out of the box if the user only did a minimal install. wwnodescan, which is installed as part of warewulf-provision-server, needs tcpdump.

nfs-utils and tcpdump are common package names on CentOS and Suse.