### PR TITLE
Add a gzip command option to provision.conf that controls compression and uncompression of bootstraps

### DIFF
--- a/provision/etc/provision.conf
+++ b/provision/etc/provision.conf
@@ -50,3 +50,7 @@ default kargs = "net.ifnames=0 biosdevname=0 quiet"
 # Path defaults to /etc/genders but it can be changed with
 # genders file /path
 generate genders
+
+# Gzip command to use for compressing bootstraps. For uncompressing
+# # command is used with "-d" with specified arguments removed.
+gzip command = gzip -9


### PR DESCRIPTION
Used primarily for overly large kernels where use of pigz speeds up things.

Code was mostly borrowed from wwvnfs.

Didn't reuse the configuration in vnfs.conf as that would be outside of the provision RPM.