### PR TITLE
Override iPXE base URL with Node's Master Attribute

### DIFF
--- a/provision/etc/dhcpd-template.conf
+++ b/provision/etc/dhcpd-template.conf
@@ -20,7 +20,7 @@ option ipxe.efi       code 36 = unsigned integer 8;
 option architecture-type   code 93  = unsigned integer 16;
 
 if exists ipxe.http and ( exists ipxe.bzimage or exists ipxe.efi ) {
-    filename "http://%{IPADDR}/WW/ipxe/cfg/${mac}";
+    filename "http://${next-server}/WW/ipxe/cfg/${mac}";
 } else {
     if option architecture-type = 00:0B {
         filename "/warewulf/ipxe/bin-arm64-efi/snp.efi";


### PR DESCRIPTION
If a node has one or more masters specified and the provision.conf option is set to `dhcp network = relay`, use the first master IP or hostname specified as the base URL in the host's IPXE cfg. This lets an admin specify arbitrary IPs or hostnames as needed in a relay configuration.