### PR TITLE
Add CLI flag to wwbootstrap to configure kernel file prefix

### DIFF
--- a/vnfs/bin/wwbootstrap
+++ b/vnfs/bin/wwbootstrap
@@ -35,6 +35,7 @@ my $opt_chroot = "";
 my $opt_output;
 my $opt_config;
 my $opt_name;
+my $opt_kernel = "vmlinuz";
 my $kversion;
 my $config;
 my $wwsh_bin;
@@ -46,6 +47,7 @@ my $help = "USAGE: $0 [options] kernel_version
 
     OPTIONS:
         -c, --chroot    Look into this chroot directory to find the kernel
+        -k, --kernel    Look for this file prefix to find the kernel (default: vmlinuz)
         -r, --root      Alias for --chroot
             --config    What configuration file should be used (don't use
                         full path, rather just the relative name as would be
@@ -60,6 +62,7 @@ my $help = "USAGE: $0 [options] kernel_version
 
     EXAMPLES:
         # wwbootstrap 2.6.32-71.el6.x86_64
+        # wwbootstrap --kernel=Image 2.6.32-71.el6.x86_64
         # wwbootstrap --config=testbootstrap 2.6.32-71.el6.x86_64
         # wwbootstrap --chroot=/path/to/chroot 2.6.32-71.el6.x86_64
         # wwbootstrap --output=test-bootstrap.wwbs 2.6.32-71.el6.x86_64
@@ -77,6 +80,7 @@ GetOptions(
     'f|file=s'      => \$opt_output,
     'o|output=s'    => \$opt_output,
     'n|name=s'      => \$opt_name,
+    'k|kernel=s'    => \$opt_kernel,
     'config=s'      => \$opt_config,
 );
 
@@ -142,6 +146,16 @@ if ($opt_output) {
     }
 }
 
+if ($opt_kernel) {
+    if ($opt_kernel =~ /^([a-zA-Z0-9_\-\.\/]+)$/) {
+        $opt_kernel = $1;
+        &iprint("Using kernel file prefix: $opt_kernel\n");
+    } else {
+        &eprint("Kernel file prefix contains illegal characters: $opt_kernel\n");
+        exit 1;
+    }
+}
+
 foreach my $dir (split(":", $ENV{"PATH"})) {
     if ($dir =~ /^([a-zA-Z0-9_\-\.\/]+)$/) {
         if (-x "$1/wwsh") {
@@ -155,8 +169,8 @@ foreach my $dir (split(":", $ENV{"PATH"})) {
 
 mkpath("$tmpdir/initramfs");
 
-if (! -f "$opt_chroot/boot/vmlinuz-$opt_kversion") {
-    &eprint("Can't locate the boot kernel: ". $opt_chroot ."/boot/vmlinuz-$opt_kversion\n");
+if (! -f "$opt_chroot/boot/$opt_kernel-$opt_kversion") {
+    &eprint("Can't locate the boot kernel: ". $opt_chroot ."/boot/$opt_kernel-$opt_kversion\n");
     exit 1;
 }
 
@@ -361,7 +375,7 @@ if ($gzip_bin =~ /^([a-zA-Z0-9\-_\/\.]+)$/) {
 
 # Attempt to gunzip the kernel, aarch64 kernels are compressed and iPXE can't boot gzip compressed kernels.
 # Note, if the kernel isn't a gzip, IO::Uncompress::Gunzip makes a direct copy of the file.
-gunzip "$opt_chroot/boot/vmlinuz-$opt_kversion" => "$tmpdir/kernel" or die "gunzip of kernel failed: $GunzipError\n";
+gunzip "$opt_chroot/boot/$opt_kernel-$opt_kversion" => "$tmpdir/kernel" or die "gunzip of kernel failed: $GunzipError\n";
 
 &nprint("Building and compressing bootstrap\n");
 system("(cd $tmpdir; find . | cpio -o --quiet -H newc ) | $gzip_bin $gzip_opts > $output");


### PR DESCRIPTION
Add CLI flag to wwbootstrap to configure kernel file prefix. Defaults to existing vmlinuz. Useful for aarch64 where Suse doesn't use vmlinuz, but Image for the Portable Executable (PE) formatted binary.