### PR TITLE
Update RPM specs to use suse_version rpm macro instead of sle_version

### DIFF
--- a/common/warewulf-common.spec.in
+++ b/common/warewulf-common.spec.in
@@ -1,6 +1,6 @@
 # Terminate specfile builds on unrecognized or unsupported OS to avoid
 # unexpected errors. This is easily overridden by setting the appropriate
-# macro (rhel, sle_version) on the rpmbuild command line.
+# macro (rhel, suse_version) on the rpmbuild command line.
 # For example, if using Fedora 20 to 27, "--define rhel 7"
 %if 0%{!?rhel:1} && 0%{?rhel_version:1}
 %global rhel %{rhel_version}
@@ -8,16 +8,16 @@
 %if 0%{?rhel:1} && 0%{?rhel} >= 7
 # RHEL >= 7.0 found; continue
 %else
-%if 0%{?sle_version:1} && 0%{?sle_version} >= 120100
-# SLES >= 12.1 found; continue
+%if 0%{?suse_version:1} && 0%{?suse_version} >= 1500
+# Suse >= 15.0 found; continue
 %else
 %{error: "Detected operating system is not supported."}
-%endif # sle_version
+%endif # suse_version
 %endif # rhel
 
 # Defining both would have unpredictable results.
-%if 0%{?rhel:1} && 0%{?sle_version:1}
-%{error: "Both rhel and sle_version macros defined. Only one is allowed."}
+%if 0%{?rhel:1} && 0%{?suse_version:1}
+%{error: "Both rhel and suse_version macros defined. Only one is allowed."}
 %endif
 
 %{!?_rel:%{expand:%%global _rel 0.%(test "@GITVERSION@" != "0000" && echo "@GITVERSION@" || git show -s --pretty=format:%h || echo 0000)}}
@@ -37,7 +37,7 @@ BuildArch: noarch
 BuildRequires: autoconf, automake
 Requires: perl(DBD::mysql), perl(DBD::Pg), perl(DBD::SQLite), perl(JSON::PP)
 
-%if 0%{?rhel:1} || 0%{?sle_version} > 150000
+%if 0%{?rhel:1} || 0%{?suse_version} >= 1500
 %global sql_name mariadb
 %global daemon_name mariadb
 %else
@@ -48,7 +48,7 @@ Requires: perl(DBD::mysql), perl(DBD::Pg), perl(DBD::SQLite), perl(JSON::PP)
 %if 0%{?rhel} >= 8
 BuildRequires: systemd
 %endif
-%if 0%{?sle_version:1}
+%if 0%{?suse_version:1}
 BuildRequires: systemd-rpm-macros
 %endif
 
@@ -131,7 +131,7 @@ SQL server.
 # Start services on install.
 # For upgrades or removal, restart after the old package is removed.
 if [ $1 -eq 1 ] ; then
-%if 0%{?sle_version:1} || 0%{?rhel} >= 8
+%if 0%{?suse_version:1} || 0%{?rhel} >= 8
 %systemd_post %{daemon_name}.service
 %else
 /usr/bin/systemctl --no-reload preset %{daemon_name}.service  &> /dev/null || :
@@ -142,7 +142,7 @@ if [ $1 -eq 1 ] ; then
 fi
 
 %postun localdb
-%if 0%{?sle_version:1} || 0%{?rhel} >= 8
+%if 0%{?suse_version:1} || 0%{?rhel} >= 8
 %systemd_postun_with_restart %{daemon_name}.service
 %else
 /usr/bin/systemctl try-restart %{daemon_name}.service  &> /dev/null || :

--- a/ipmi/warewulf-ipmi.spec.in
+++ b/ipmi/warewulf-ipmi.spec.in
@@ -14,7 +14,7 @@ Conflicts: warewulf < 3
 Requires: warewulf-common
 Requires: %{name}-initramfs-%{_arch} = %{version}-%{release}
 
-%if 0%{?rhel} >= 8 || 0%{?sle_version} >= 150000
+%if 0%{?rhel} >= 8 || 0%{?suse_version} >= 1500
 %global localipmi 1
 BuildRequires: ipmitool
 Requires: ipmitool

--- a/provision/warewulf-provision.spec.in
+++ b/provision/warewulf-provision.spec.in
@@ -29,7 +29,7 @@ BuildRequires: bsdtar
 %else # rhel < 8
 %global dhcpsrv dhcp
 %endif # rhel 8
-%else # sle_version
+%else # suse_version
 BuildRequires: systemd-rpm-macros
 %global httpsvc apache2
 %global httpgrp www
@@ -51,8 +51,8 @@ BuildRequires: gcc-x86_64-linux-gnu
 %undefine CROSS_FLAG
 %endif # cross_compile
 
-# New RHEL and SLE include the required FS tools
-%if 0%{?rhel} >= 8 || 0%{?sle_version} >= 150000
+# New RHEL and Suse include the required FS tools
+%if 0%{?rhel} >= 8 || 0%{?suse_version} >= 1500
 %global localtools 1
 BuildRequires: parted, e2fsprogs
 Requires: parted, autofs, e2fsprogs
@@ -151,11 +151,11 @@ Requires: %{httpsvc}, perl(Apache), %{tftpsvc}, %{dhcpsrv}, tcpdump
 %if 0%{?rhel} >= 8
 Requires(post): policycoreutils-python-utils
 %else # Not RHEL 8+
-%if 0%{?sle_version} >= 150100
+%if 0%{?suse_version} >= 1500
 Requires(post): policycoreutils
 %else # Not RHEL 8+ or SLE 15.1+
 Requires(post): policycoreutils-python
-%endif # sle_version
+%endif # suse_version
 %endif # rhel
 
 %description server
@@ -174,7 +174,7 @@ do not require this package.
 if [ $1 -eq 1 ] ; then
 usermod -a -G warewulf %{httpgrp} >/dev/null 2>&1 || :
 %{__mkdir_p} %{wwsrvdir}/warewulf/ipxe %{wwsrvdir}/warewulf/bootstrap 2>/dev/null || :
-%if 0%{?sle_version:1} || 0%{?rhel} >= 8
+%if 0%{?suse_version:1} || 0%{?rhel} >= 8
 %systemd_post %{httpdsvc}.service >/dev/null 2>&1 || :
 %systemd_post %{tftpsvc}.socket >/dev/null 2>&1 || :
 %else
@@ -198,7 +198,7 @@ semanage fcontext -d -t httpd_sys_content_t '%{wwsrvdir}/warewulf/ipxe(/.*)?' 2>
 semanage fcontext -d -t httpd_sys_content_t '%{wwsrvdir}/warewulf/bootstrap(/.*)?' 2>/dev/null || :
 /sbin/restorecon -R %{wwsrvdir}/warewulf || :
 fi
-%if 0%{?sle_version:1} || 0%{?rhel} >= 8
+%if 0%{?suse_version:1} || 0%{?rhel} >= 8
 %systemd_postun_with_restart %{httpdsvc}.service >/dev/null 2>&1 || :
 %systemd_postun_with_restart %{tftpsvc}.socket >/dev/null 2>&1 || :
 %else


### PR DESCRIPTION
Update RPM specs to use suse_version rpm macro instead of sle_version as the former is available on OpenSuse 15.3. sle_version seems to have been removed after OpenSuse 15.2. Seems suse_version its always set to 1500 on SLES and OpenSUSE 15 systems I sampled.