### PR TITLE
vnfs: SUSE Templates - Leap 15.1 -> Leap 15.3, added SLE-15

### DIFF
--- a/vnfs/libexec/wwmkchroot/Makefile.am
+++ b/vnfs/libexec/wwmkchroot/Makefile.am
@@ -1,6 +1,6 @@
 wwmkchrootdir = $(libexecdir)/warewulf/wwmkchroot
 
-dist_wwmkchroot_SCRIPTS = centos-6.tmpl centos-7.tmpl include-rhel sl-7.tmpl functions include-deb debian-8.tmpl debian7-32.tmpl debian7-64.tmpl golden-system.tmpl include-suse opensuse-42.3.tmpl opensuse-15.1.tmpl opensuse-tumbleweed.tmpl sles-12.tmpl include-ubuntu ubuntu-16.04.tmpl ubuntu-18.04.tmpl centos-8.tmpl sles-15.tmpl
+dist_wwmkchroot_SCRIPTS = centos-6.tmpl centos-7.tmpl include-rhel sl-7.tmpl functions include-deb debian-8.tmpl debian7-32.tmpl debian7-64.tmpl golden-system.tmpl include-suse opensuse-42.3.tmpl opensuse-15.3.tmpl opensuse-tumbleweed.tmpl sles-12.tmpl sle-15.tmpl include-ubuntu ubuntu-16.04.tmpl ubuntu-18.04.tmpl centos-8.tmpl sles-15.tmpl
  
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/vnfs/libexec/wwmkchroot/include-suse
+++ b/vnfs/libexec/wwmkchroot/include-suse
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # Include file for SUSE Linux distributions
-# Use this for SLE, OpenSUSE LEAP, and Tumbleweed
+# Use this for SLE, openSUSE LEAP, and Tumbleweed
 
 distro_check() {
     if ! zypper --version >$DEVNULL ; then
@@ -55,7 +55,10 @@ prechroot() {
         ZYPP_MIRROR="$OS_MIRROR"
     fi
 
-    if [ -z "$ZYPP_MIRROR" -a -z "$INSTALL_ISO" ]; then
+    # If neither ZYPP_MIRROR nor INSTALL_ISO are set, try to copy repository
+    # information from running system (including credentials on SLE)
+    # If none of these are available, our options are exhausted: fail early
+    if [ -z "$ZYPP_MIRROR" -a -z "$INSTALL_ISO" -a ! -d /etc/zypp ]; then
         echo "ERROR: You must define the \$ZYPP_MIRROR or \$INSTALL_ISO variable"
         cleanup
         return 1
@@ -83,20 +86,23 @@ prechroot() {
     [ -n "$VERBOSE" ] && echo "Created zypp.conf"
     [ -n "$DEBUG" ] && cat z$CHROOTDIR/etc/zypp/zypp.conf
 
-    # Add all of the repos found on the ISO images
+    # Remove all existing repos in CHROOT; just a precaution
+    rm -f $CHROOTDIR/etc/zypp/repos.d/*
 
-    if [ -n "$INSTALL_ISO" ]; then
+    if [ -z "$ZYP_MIRROR" -a -z "$INSTALL_ISO" ]; then
+	echo "INFO: Taking repository information from running system"
+	cp -rap /etc/zypp/repos.d $CHROOTDIR/etc/zypp
+	[ -d /etc/zypp/services.d ] && cp -rap /etc/zypp/services.d $CHROOTDIR/etc/zypp
+	[ -d /etc/zypp/credentials.d ] && cp -rap /etc/zypp/credentials.d $CHROOTDIR/etc/zypp
+    elif [ -n "$INSTALL_ISO" ]; then
+	# Add all of the repos found on the ISO images
         for i in $(find $MEDIA_MOUNTPATH -type d -name repodata -printf "%P "); do
              [ -n "$VERBOSE" ] && echo "Found repodata at $i"
-             INSTALLDIRS="$INSTALLDIRS,file:///tmp/wwmkchroot.mount/$(dirname $i)"
+             INSTALLDIRS="${INSTALLDIRS:+${INSTALLDIRS}},file:///tmp/wwmkchroot.mount/$(dirname $i)"
         done
-        ZYPP_MIRROR="$ZYPP_MIRROR,$INSTALLDIRS"
+        ZYPP_MIRROR="${ZYPP_MIRROR:+${ZYPP_MIRROR}},$INSTALLDIRS"
         [ -n "$DEBUG" ] && echo "ZYPP_MIRROR = $ZYPP_MIRROR"
     fi
-
-    # Remove all existing repos in CHROOT; just a precaution
-    rm -f $CHROOTDIR/etc/yum.repos.d/*
-
 
     # Create new repos from comma-seperated list (using bash inline S&R)
     if [ "01" -eq "0$REPO_NOGPGCHECK" ]; then

--- a/vnfs/libexec/wwmkchroot/opensuse-15.3.tmpl
+++ b/vnfs/libexec/wwmkchroot/opensuse-15.3.tmpl
@@ -1,4 +1,4 @@
-#DESC: OpenSUSE LEAP 15.1
+#DESC: openSUSE LEAP 15.3
 # The general SUSE include has all of the necessary functions, but requires
 # some basic variables specific to each chroot type to be defined.
 
@@ -10,27 +10,28 @@
 # Uncomment to disable GPG checks on added repos
 # REPO_NOGPGHECK=1
 
-# Comma-seperated location(s) of the YUM repositories
+# Comma-seperated location(s) of the zypper repositories
 if [ "$(uname -m)" = "x86_64" ]; then
-    ZYPP_MIRROR="http://download.opensuse.org/distribution/leap/15.1/repo/oss/,\
-http://download.opensuse.org/update/leap/15.1/oss/"
+    ZYPP_MIRROR="http://download.opensuse.org/distribution/leap/15.3/repo/oss/,\
+http://download.opensuse.org/update/leap/15.3/oss/"
     # URLs for OpenSUSE LEAP 15.0
     #ZYPP_MIRROR="http://download.opensuse.org/distribution/leap/15.0/repo/oss/,\
 #http://download.opensuse.org/update/leap/15.0/oss/"
 elif [ "$(uname -m)" = "aarch64" ]; then
-    ZYPP_MIRROR="http://download.opensuse.org/ports/aarch64/distribution/leap/15.1/repo/oss/,\
-http://download.opensuse.org/ports/aarch64/update/leap/15.1/oss/"
+    ZYPP_MIRROR="http://download.opensuse.org/ports/aarch64/distribution/leap/15.3/repo/oss/,\
+http://download.opensuse.org/ports/aarch64/update/leap/15.3/oss/"
 else
     echo "Unsupported Architecture"
     exit 1
 fi
 
 # Install only what is necessary/specific for this distribution
-PKGLIST="systemd-sysvinit aaa_base bash dracut openSUSE-release coreutils \
+PKGLIST="systemd-sysvinit aaa_base bash dracut distribution-release coreutils \
     e2fsprogs ethtool filesystem findutils gawk grep iproute2 iputils \
     mingetty net-tools nfs-kernel-server pam rpcbind procps psmisc shadow \
     rsync sed rsyslog tcpd timezone util-linux tar less gzip kmod-compat \
-    udev openssh dhcp-client pciutils vim strace cron cpupower cpio wget zypper"
+    udev openssh dhcp-client pciutils vim strace cron cpupower cpio wget
+    zypper netcfg ncurses-utils"
 
 
 

--- a/vnfs/libexec/wwmkchroot/sle-15.tmpl
+++ b/vnfs/libexec/wwmkchroot/sle-15.tmpl
@@ -1,26 +1,26 @@
-#DESC: OpenSUSE Tumbleweed Rolling Release
-
-. include-suse
-
+#DESC: SUSE SLE 15 (all service packs)
 # The general SUSE include has all of the necessary functions, but requires
 # some basic variables specific to each chroot type to be defined.
+
+. include-suse
 
 # Uncomment and set to use a specific kernel version
 # KVERSION=latest
 
 # Uncomment to disable GPG checks on added repos
-# REPO_NOGPGCHECK=1
+# REPO_NOGPGHECK=1
 
-# Define the location of the YUM repository
-ZYPP_MIRROR="http://download.opensuse.org/tumbleweed/repo/oss/"
+# Comma-seperated location(s) of the zypper repositories
+# For SLE don't use a download repo, use repo from installed product.
+ZYPP_MIRROR=
 
 # Install only what is necessary/specific for this distribution
-PKGLIST="systemd-sysvinit aaa_base bash dracut openSUSE-release coreutils \
+PKGLIST="systemd-sysvinit aaa_base bash dracut distribution-release coreutils \
     e2fsprogs ethtool filesystem findutils gawk grep iproute2 iputils \
     mingetty net-tools nfs-kernel-server pam rpcbind procps psmisc shadow \
     rsync sed rsyslog tcpd timezone util-linux tar less gzip kmod-compat \
     udev openssh dhcp-client pciutils vim strace cron cpupower cpio wget
-    zypper netcfg ncurses-utils glibc-locale-base"
+    zypper netcfg ncurses-utils"
 
 
 


### PR DESCRIPTION
- Change Leap 15.1 template to Leap 15.3.
- Change openSUSE-release -> distrobution-release
- Add SLE-15 template (valid for all service packs).
  Leave ZYPP_MIRROR empty, this will retrieve the zypper data
  from the currently installed product.

Signed-off-by: Egbert Eich <eich@suse.com>