### PR TITLE
cluster: If hostname has no domain part try FQDN

### DIFF
--- a/cluster/libexec/wwinit/30-domain.init
+++ b/cluster/libexec/wwinit/30-domain.init
@@ -33,8 +33,12 @@ fi
 HOSTNAME=`hostname`
 DOMAIN=`echo $HOSTNAME | sed -e 's/^[^\.]*\.//'`
 
-if [ -z "$DOMAIN" -o "$HOSTNAME" == "$DOMAIN" ]; then
-    DOMAIN="cluster"
+if [ -z "$DOMAIN" -o "$HOSTNAME" = "$DOMAIN" ]; then
+    HOSTNAME=`hostname -f`
+    DOMAIN=`echo $HOSTNAME | sed -e 's/^[^\.]*\.//'`
+    if [ -z "$DOMAIN" -o "$HOSTNAME" = "$DOMAIN" ]; then
+        DOMAIN="cluster"
+    fi
 fi
 
 wwprint "Setting default node domain to: \"$DOMAIN\""


### PR DESCRIPTION
SUSE doesn't include the domainname in the hostname. One may still
set the domain name using DNS or /etc/hosts.
Call 'hostname -f' to get the FQDN and try to separate the domain
part from it.

Signed-off-by: Egbert Eich <eich@suse.com>