### PR TITLE
provision: Fix 'fake' cross compile

### DIFF
--- a/provision/3rd_party/Makefile.am
+++ b/provision/3rd_party/Makefile.am
@@ -60,14 +60,14 @@ endif
 bin-arm64-efi/snp.efi: prep
 
 if BUILD_ARM64
-	@ if [ `$(CROSS_COMPILE_ARM64)gcc -dumpversion` == 4.8.5 ]; then \
-    ( cd _work && pwd && patch -N -p1 < ../$(IPXE_PATCH) ) ; \
-	fi ; \
-	if [ -n "@local_ipxe_snp_arm64_path@" -a -f "@local_ipxe_snp_arm64_path@" ]; then \
+	@if [ -n "@local_ipxe_snp_arm64_path@" -a -f "@local_ipxe_snp_arm64_path@" ]; then \
 		echo "Detected local install of arm64 snp.efi boot image. Bypassing build process." ;\
 		mkdir -p _work/$(IPXE_DIR)/src/bin-arm64-efi ;\
 		cp "@local_ipxe_snp_arm64_path@" _work/$(IPXE_DIR)/src/bin-arm64-efi/snp.efi ;\
 	else \
+	   if [ `$(CROSS_COMPILE_ARM64)gcc -dumpversion` == 4.8.5 ]; then \
+	      ( cd _work && pwd && patch -N -p1 < ../$(IPXE_PATCH) ) ; \
+	   fi ; \
 	$(MAKE) -C _work/$(IPXE_DIR)/src CROSS_COMPILE=$(CROSS_COMPILE_ARM64) bin-arm64-efi/snp.efi; \
   fi
 endif

--- a/provision/configure.ac
+++ b/provision/configure.ac
@@ -208,7 +208,7 @@ AS_CASE([$host_cpu],
         build_x86_64=yes
         AS_IF([test "x$enable_cross_compile" = "xyes"], [
             AC_MSG_NOTICE([cross-compile for aarch64 configured])
-            CROSS_COMPILE_ARM64=`basename $CROSS_AARCH64_GCC gcc`
+            CROSS_COMPILE_ARM64=`basename "$CROSS_AARCH64_GCC" gcc`
             build_arm64=yes
         ])
     ],
@@ -217,7 +217,7 @@ AS_CASE([$host_cpu],
         build_arm64=yes
         AS_IF([test "x$enable_cross_compile" = "xyes"], [
             AC_MSG_NOTICE([cross-compile for x86_64 configured])
-            CROSS_COMPILE_X86_64=`basename $CROSS_X86_64_GCC gcc`
+            CROSS_COMPILE_X86_64=`basename "$CROSS_X86_64_GCC" gcc`
             build_x86_64=yes
         ])
     ]


### PR DESCRIPTION
When arm binaries are taken from installed iPXE files, there is
no need for a cross compiler to be installed. Make sure a build
to look for a compiler only when it is actually required.

Signed-off-by: Egbert Eich <eich@suse.com>