### PR TITLE
vnfs: Remove hard coded PATH in wwvnfs

### DIFF
--- a/vnfs/bin/wwvnfs
+++ b/vnfs/bin/wwvnfs
@@ -23,7 +23,6 @@ use Fcntl ':mode';
 use POSIX;
 {
     local $^W = 0;
-    $ENV{PATH} = '/bin:/usr/bin';
     if (eval { require "sys/sysmacros.ph"; }) {
       require "sys/sysmacros.ph"
     }


### PR DESCRIPTION
The PATH variable was set to /bin:/usr/bin in
  commit 7479150925dbad1576275ed9d7317b047b063678
  Author: jcsiadal <jeremy.c.siadal@intel.com>
  Date:   Wed Oct 16 22:10:47 2019 -0700

This leads to problems when warewulf is installed to any other
path (like the autotool default /usr/local).
The patch description did not state a reason why. Possibly a
debugging leftover? Let's remove it.

Signed-off-by: Egbert Eich <eich@suse.com>