### PR TITLE
Manually Merge #231 - Added mdadm support for provision

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
                  perl-DBD-MySQL perl-DBI perl-Digest perl-Digest-MD5 perl-IO-Compress \
                  perl-Sys-Syslog perl-Test-Simple xz-devel ipmitool parted autofs \
                  e2fsprogs libarchive perl-Test-Harness perl-JSON-PP bsdtar which \
-                 libtirpc-devel mbedtls-devel
+                 mdadm xfsprogs libtirpc-devel mbedtls-devel
           name: "Install Build Dependencies"
       -
         run:
@@ -163,7 +163,8 @@ jobs:
               set -o nounset
               cd provision
               ./autogen.sh --with-local-e2fsprogs --with-local-libarchive \
-                 --with-local-parted --with-local-partprobe
+                 --with-local-parted --with-local-partprobe --with-local-mdadm \
+                 --with-local-xfsprogs
               make dist-gzip
               rpmbuild -D "_sourcedir $PWD" -D "cross_compile 0" \
                  -D "mflags -j$(/usr/bin/getconf _NPROCESSORS_ONLN)" \

--- a/provision/configure.ac
+++ b/provision/configure.ac
@@ -163,6 +163,7 @@ FIND_LOCAL(parted, parted)
 FIND_LOCAL(partprobe, partprobe)
 FIND_LOCAL(xfsprogs, mkfs.xfs)
 FIND_LOCAL(curl, curl)
+FIND_LOCAL(mdadm, mdadm)
 
 #AC_CHECK_LIB(fuse, fuse_main, , [
 #AC_MSG_ERROR([Fatal:  Fuse libraries not found.])

--- a/provision/etc/filesystem/examples/Makefile.am
+++ b/provision/etc/filesystem/examples/Makefile.am
@@ -1,6 +1,6 @@
 confdir = $(sysconfdir)/warewulf/filesystem/examples
 
-dist_conf_DATA = efi_example.cmds efi_nvme_example.cmds gpt_example.cmds gpt_label_example.cmds gpt_uuid_example.cmds hybrid_example.cmds mbr_example.cmds tmpfs_example.cmds
+dist_conf_DATA = efi_example.cmds efi_nvme_example.cmds gpt_example.cmds gpt_label_example.cmds gpt_raid_example.cmds gpt_uuid_example.cmds hybrid_example.cmds mbr_example.cmds tmpfs_example.cmds
 
 MAINTAINERCLEANFILES = Makefile.in
 

--- a/provision/etc/filesystem/examples/gpt_raid_example.cmds
+++ b/provision/etc/filesystem/examples/gpt_raid_example.cmds
@@ -1,0 +1,29 @@
+# RAID5 Example
+
+# Parted specific commands
+select /dev/sda
+mklabel gpt
+mkpart primary 0% 100%
+set 1 raid on
+
+select /dev/sdb
+mklabel gpt
+mkpart primary 0% 100%
+set 1 raid on
+
+select /dev/sdc
+mklabel gpt
+mkpart primary 0% 100%
+set 1 raid on
+
+# Create RAID5 on /dev/md0: raidX NUMBER PARTITIONS...
+raid5 0 sda1 sdb1 sdc1
+
+# the above command also selects /dev/md, so filesystems can be created:
+# select /dev/md
+
+# Create filesystem on /dev/md0
+mkfs 0 ext4 -L root
+
+# fstab NUMBER fs_file fs_vfstype fs_mntops fs_freq fs_passno
+fstab 0 / ext4 defaults 0 0

--- a/provision/initramfs/Makefile.am
+++ b/provision/initramfs/Makefile.am
@@ -165,8 +165,10 @@ rootfs: busybox e2fsprogs xfsprogs libarchive parted curl mdadm
 	fi
 	if [ -n "@local_e2fsprogs_path@" -a -f "@local_e2fsprogs_path@" ]; then \
 		cp -av "@local_e2fsprogs_path@" rootfs/sbin/mkfs.ext4 ;\
+		cp -av "/etc/mke2fs.conf" rootfs/etc/mke2fs.conf ;\
 	else \
 		cp -av _work/$(E2FSPROGS_DIR)/misc/mke2fs rootfs/sbin/mkfs.ext4 ;\
+		cp -av _work/$(E2FSPROGS_DIR)/misc/mke2fs.conf rootfs/etc/mkfs.ext4 ;\
 	fi
 	ln -s mkfs.ext4 rootfs/sbin/mkfs.ext3
 	if [ -n "@local_xfsprogs_path@" -a -f "@local_xfsprogs_path@" ]; then \

--- a/provision/initramfs/Makefile.am
+++ b/provision/initramfs/Makefile.am
@@ -179,9 +179,9 @@ rootfs: busybox e2fsprogs xfsprogs libarchive parted curl mdadm
 	fi
 	if [ -n "@local_parted_path@" -a -f "@local_parted_path@" -a \
 	  -n "@local_partprobe_path@" -a -f "@local_partprobe_path@" ]; then \
-		rm -f rootfs/usr/sbin/partprobe; \
-		cp -av "@local_parted_path@" rootfs/usr/sbin/parted; \
-		cp -av "@local_partprobe_path@" rootfs/usr/sbin/partprobe; \
+		rm -f rootfs/usr/sbin/partprobe rootfs/sbin/partprobe; \
+		cp -av "@local_parted_path@" rootfs/sbin/parted; \
+		cp -av "@local_partprobe_path@" rootfs/sbin/partprobe; \
 	else \
 		rm -f rootfs/usr/sbin/partprobe; \
 		$(MAKE) -C _work/$(PARTED_DIR)/ DESTDIR=`pwd`/rootfs install; \

--- a/provision/initramfs/Makefile.am
+++ b/provision/initramfs/Makefile.am
@@ -55,7 +55,7 @@ e2fsprogs:
 
 xfsprogs:
 	@ if [ -n "@local_xfsprogs_path@" -a -f "@local_xfsprogs_path@" ]; then \
-                echo "Detected local install of xfsprogs. Bypassing xfsprogs build process." ;\
+                echo "Detected local install of xfsprogs." ;\
 	fi
 
 busybox:
@@ -133,7 +133,12 @@ curl:
 		fi \
 	fi
 
-rootfs: busybox e2fsprogs xfsprogs libarchive parted curl
+mdadm:
+	@ if [ -n "@local_mdadm_path@" -a -f "@local_mdadm_path@" ]; then \
+		echo "Detected local install of mdadm." ;\
+	fi
+
+rootfs: busybox e2fsprogs xfsprogs libarchive parted curl mdadm
 	rm -rf rootfs
 	mkdir rootfs
 	mkdir rootfs/bin
@@ -183,6 +188,9 @@ rootfs: busybox e2fsprogs xfsprogs libarchive parted curl
 		cp -av "@local_curl_path@" rootfs/bin/curl; \
 	else \
 		cp -av _work/$(CURL_DIR)/src/curl rootfs/bin/curl; \
+	fi
+	if [ -n "@local_mdadm_path@" -a -f "@local_mdadm_path@" ]; then \
+		cp -av @local_mdadm_path@ rootfs/sbin/mdadm; \
 	fi
 	cp -L --parents /lib*/ld-linux* rootfs/
 	cp -L --parents /lib*/libnss_dns* rootfs/

--- a/provision/initramfs/Makefile.am
+++ b/provision/initramfs/Makefile.am
@@ -179,9 +179,11 @@ rootfs: busybox e2fsprogs xfsprogs libarchive parted curl mdadm
 	fi
 	if [ -n "@local_parted_path@" -a -f "@local_parted_path@" -a \
 	  -n "@local_partprobe_path@" -a -f "@local_partprobe_path@" ]; then \
+		rm -f rootfs/usr/sbin/partprobe; \
 		cp -av "@local_parted_path@" rootfs/usr/sbin/parted; \
 		cp -av "@local_partprobe_path@" rootfs/usr/sbin/partprobe; \
 	else \
+		rm -f rootfs/usr/sbin/partprobe; \
 		$(MAKE) -C _work/$(PARTED_DIR)/ DESTDIR=`pwd`/rootfs install; \
 	fi
 	if [ -n "@local_curl_path@" -a -f "@local_curl_path@" ]; then \

--- a/provision/initramfs/Makefile.am
+++ b/provision/initramfs/Makefile.am
@@ -168,7 +168,7 @@ rootfs: busybox e2fsprogs xfsprogs libarchive parted curl mdadm
 		cp -av "/etc/mke2fs.conf" rootfs/etc/mke2fs.conf ;\
 	else \
 		cp -av _work/$(E2FSPROGS_DIR)/misc/mke2fs rootfs/sbin/mkfs.ext4 ;\
-		cp -av _work/$(E2FSPROGS_DIR)/misc/mke2fs.conf rootfs/etc/mkfs.ext4 ;\
+		cp -av _work/$(E2FSPROGS_DIR)/misc/mke2fs.conf rootfs/etc/mke2fs.conf ;\
 	fi
 	ln -s mkfs.ext4 rootfs/sbin/mkfs.ext3
 	if [ -n "@local_xfsprogs_path@" -a -f "@local_xfsprogs_path@" ]; then \

--- a/provision/initramfs/capabilities/setup-filesystems/20-filesystems
+++ b/provision/initramfs/capabilities/setup-filesystems/20-filesystems
@@ -23,6 +23,32 @@ set -o pipefail
 # By default mount a tmpfs volumne for root
 WWFS=${WWFS:="select tmpfs,fstab "" / tmpfs rw:relatime:mode=555 0 0"}
 
+WWDISKWAIT=${WWDISKWAIT:=5}
+
+wait_for_disk() {
+  local DISK="$1"
+  local RETRY=0
+  if [ -z "${DISK##*/dev/*}" ]; then
+    while [ ! -b "${DISK}" ]; do
+      if [ "${RETRY}" -lt "${WWDISKWAIT}" ]; then
+        if [ "${RETRY}" -eq 0 ]; then
+          msg_gray "   * ${DISK} not ready, retrying."
+        else
+          msg_gray "."
+        fi
+        RETRY="$((RETRY+1))"
+        sleep 1
+      else
+        wwlogger "Disk: ${DISK} not found!"
+        exit 2
+      fi
+    done
+    if [ "${RETRY}" -gt 0 ]; then
+      wwsuccess
+    fi
+  fi
+}
+
 run_parted() {
   local SELECT_DISK="${1}"
   local PARTED_CMDS="${2}"
@@ -56,6 +82,8 @@ run_mkfs() {
 
   if [ -x /usr/bin/udevadm ]; then
     /usr/bin/udevadm settle --timeout=15 --exit-if-exists="${DEV}"
+  else
+    wait_for_disk "${DEV}"
   fi
 
   msg_gray "   * formatting ${DEV}"
@@ -116,6 +144,68 @@ run_mkfs() {
   esac
 }
 
+run_mdadm() {
+  local LEVEL="${1}"
+  local NUMBER="${2}"
+
+  if [ -z "${LEVEL}" ]; then
+    wwlogger "No raid level specified"
+    exit 2
+  fi
+
+  if [ -z "${NUMBER}" ]; then
+    wwlogger "No raid number given for raid${LEVEL}"
+    exit 2
+  fi
+
+  shift 2
+  local COUNT="$#"
+  local DEVICES
+  local DEV
+
+  if [ ${COUNT} -eq 0 ]; then
+    wwlogger "No devices specified for raid${LEVEL} on /dev/md${NUMBER}"
+    exit 2
+  fi
+
+  local MSG="   * creating raid${LEVEL} on /dev/md${NUMBER} for ${*}"
+  msg_gray "${MSG}"
+  local MSG_REPEAT=0
+
+  for DEV in ${@:-}; do
+    case "${DEV}" in
+      missing|-)
+        DEVICES="${DEVICES} missing"
+      ;;
+      *)
+        DEV="/dev/${DEV##*/dev/}"
+        if [ -x /usr/bin/udevadm ]; then
+          /usr/bin/udevadm settle --timeout=15 --exit-if-exists="${DEV}"
+        else
+          if [ ! -b "${DEV}" ]; then
+            wwrunning
+            wait_for_disk "${DEV}"
+            MSG_REPEAT=1
+          fi
+        fi
+        DEVICES="$DEVICES ${DEV}"
+      ;;
+    esac
+  done
+
+  if [ ${MSG_REPEAT} = 1 ]; then
+    msg_gray "${MSG}"
+  fi
+
+  {
+    # This is ugly but mdadm always asks for confirmation if disks are not empty, so we need /usr/bin/yes
+    (/usr/bin/yes || /bin/true) | /sbin/mdadm --create "/dev/md${NUMBER}" -f "--level=${LEVEL}" --raid-devices=${COUNT} ${DEVICES} >/dev/null 2>&1 && wwsuccess
+  } || {
+    wwfailure
+    exit 2
+  }
+}
+
 update_fstab_and_mount() {
   local SELECT_DISK="${1}"
   local ENTRY="${2}"
@@ -168,7 +258,7 @@ update_fstab_and_mount() {
     # Don't pass select commands directly to parted as parted --script 
     # needs a device specified on the CLI
     select*)
-      if [ "${FIRST_DISK}" ]; then
+      if [ "${FIRST_DISK}" -eq 1 ]; then
         FIRST_DISK=0
       else
         # Run any accumulated parted commands before changing selected disk
@@ -177,27 +267,8 @@ update_fstab_and_mount() {
         SELECT_DISK=""
       fi
       SELECT_DISK=$(echo "${FSCMD}" | cut -f 2 -d' ')
-
-      SELECT_RETRY=0
-
-      if [ -z "${SELECT_DISK##*/dev/*}" ]; then
-        while [ ! -b "${SELECT_DISK}" ]; do
-          if [ "${SELECT_RETRY}" -lt "${WWSELECTDISKWAIT}" ]; then
-            if [ "${SELECT_RETRY}" -eq 0 ]; then
-              msg_gray "   * ${SELECT_DISK} not ready, retrying."
-            else
-              msg_gray "."
-            fi
-            SELECT_RETRY="$((SELECT_RETRY+1))"
-            sleep 1
-          else
-            wwlogger "Disk: ${SELECT_DISK} not found!"
-            exit 2
-          fi
-        done
-        if [ "${SELECT_RETRY}" -gt 0 ]; then
-          wwsuccess
-        fi
+      if [ "${SELECT_DISK}" != "/dev/md" ]; then
+        wait_for_disk "${SELECT_DISK}"
       fi
     ;;
 
@@ -226,6 +297,20 @@ update_fstab_and_mount() {
       unset IFS
       run_mkfs "${SELECT_DISK}" ${FSCMD:5}
       IFS=","
+    ;;
+
+    raid0*|raid1*|raid4*|raid5*|raid6*)
+      # Run any accumulated parted commands before continuing with raid
+      run_parted "${SELECT_DISK}" "${PARTED_CMDS}"
+      PARTED_CMDS=""
+
+      # Need FSCMD to be split into individual arguments for run_mdadm
+      unset IFS
+      run_mdadm ${FSCMD:4}
+      IFS=","
+
+      # Now select /dev/md for filesystem creation
+      SELECT_DISK=/dev/md
     ;;
 
     # All parted command except select

--- a/provision/initramfs/init
+++ b/provision/initramfs/init
@@ -83,18 +83,18 @@ bondup() {
     msg_white "Configuring bonding interfaces: $DEVICE $WWBONDMODE ($BONDDEVS)\n"
 
     msg_gray "Loading bonding module\n"
-# dont automatically created devices
+    # dont automatically created devices
     modprobe bonding max_bonds=0 >/dev/null
 
     for slave in $BONDDEVS; do
         ip addr flush dev $slave >/dev/null
-#        ip link set dev $slave nomaster down >/dev/null 2>&1 
+        # ip link set dev $slave nomaster down >/dev/null 2>&1
     done
 
     msg_gray "Bringing up interface $DEVICE"
 
     ip link add $DEVICE type bond >/dev/null 
-# busybox "ip" command does not support bonding modes
+    # busybox "ip" command does not support bonding modes
     echo "$WWBONDMODE" > /sys/class/net/$DEVICE/bonding/mode
     ip link set dev $DEVICE up
 
@@ -110,7 +110,7 @@ bondup() {
             fi
         fi
 
-# give the device some time to come up
+        # give the device some time to come up
         sleep 5
         
         if [ -n "$WWIPADDR" -a -n "$WWNETMASK" -a -n "$WWMASTER" ]; then
@@ -192,8 +192,8 @@ bondup() {
                     if [ -n "$WWBONDMODE" ]; then
                         echo "BONDING_OPTS=\"mode=$WWBONDMODE\"" >> /tmp/ifcfg-$DEVICE
                     fi
-		    # SUSE based ifcfg
-		    mkdir -p /tmp/suse
+                    # SUSE based ifcfg
+                    mkdir -p /tmp/suse
 
                     echo "# This was created by the Warewulf bootstrap" > /tmp/suse/ifcfg-$DEVICE
                     echo "NAME=$DEVICE" >> /tmp/suse/ifcfg-$DEVICE
@@ -216,12 +216,12 @@ bondup() {
                     fi
                     COUNT=0
                     for slave in $BONDDEVS; do
-			echo "BONDIG_SLAVE_$COUNT=$slave" >> /tmp/suse/ifcfg-$DEVICE
+                        echo "BONDIG_SLAVE_$COUNT=$slave" >> /tmp/suse/ifcfg-$DEVICE
                         echo "# This was created by the Warewulf bootstrap" > /tmp/ifcfg-$slave
                         echo "NAME=$slave" >> /tmp/suse/ifcfg-$slave
                         echo "BOOTPROTO=none" >> /tmp/suse/ifcfg-$slave
                         echo "STARTMODE=hotplug" >> /tmp/suse/ifcfg-$slave
-			COUNT=`expr $COUNT + 1`
+                        COUNT=`expr $COUNT + 1`
                     done
                     wwsuccess
                 fi
@@ -296,7 +296,7 @@ netconf_distro()
         fi
 
         # SUSE based ifcfg
-	mkdir -p /tmp/suse
+        mkdir -p /tmp/suse
         echo "# This was created by the Warewulf bootstrap" > /tmp/suse/ifcfg-$OSDEVICE
         echo "NAME=$OSDEVICE" >> /tmp/suse/ifcfg-$OSDEVICE
         echo "BOOTPROTO=static" >> /tmp/suse/ifcfg-$OSDEVICE
@@ -349,7 +349,7 @@ ifup() {
                     fi
                 fi
 
-		netconf_distro
+                netconf_distro
 
                 COUNT=0
                 msg_white  "Trying to reach the master node at $WWMASTER "
@@ -377,7 +377,7 @@ ifup() {
                 msg_gray "($IPADDR/$NETMASK)"
                 wwsuccess
 
-		netconf_distro
+                netconf_distro
                 return 0
             fi
             msg_white "."

--- a/provision/lib/Warewulf/Provision.pm
+++ b/provision/lib/Warewulf/Provision.pm
@@ -587,6 +587,12 @@ sub fs()
       "version" => 0,
       "mkfs" => 2,
       "fstab" => 6,
+      "raid0" => 2,
+      "raid1" => 2,
+      "raid4" => 2,
+      "raid5" => 2,
+      "raid6" => 2,
+      "raid10" => 2,
     );
 
     my $fs_cmds_dir = Warewulf::ACVars->get("SYSCONFDIR") . "/warewulf/filesystem/";

--- a/provision/warewulf-provision.spec.in
+++ b/provision/warewulf-provision.spec.in
@@ -66,16 +66,17 @@ BuildRequires: cross-x86_64-gcc7
 # New RHEL and Suse include the required FS tools
 %if 0%{?rhel} >= 8 || 0%{?suse_version} >= 1500
 %global localtools 1
-BuildRequires: parted, e2fsprogs
+BuildRequires: parted, e2fsprogs, mdadm, xfsprogs
 Requires: parted, autofs, e2fsprogs
 BuildRequires: libarchive.so.13()(64bit)
 Requires: libarchive.so.13()(64bit)
-%global CONF_FLAGS --with-local-e2fsprogs --with-local-libarchive --with-local-parted --with-local-partprobe
+%global CONF_FLAGS --with-local-e2fsprogs --with-local-libarchive --with-local-parted --with-local-partprobe --with-local-mdadm --with-local-xfsprogs
 %else
 %global localtools 0
 Requires: %{name}-gpl_sources = %{version}-%{release}
+Provides: curl = 7.79.1
 Provides: parted = 3.4
-Provides: e2fsprogs = 1.44.6
+Provides: e2fsprogs = 1.46.4
 Provides: libarchive = 3.5.2
 Provides: libarchive.so.13()(64bit)
 %endif


### PR DESCRIPTION
Manually merged in the great work of @macdems in #231:

Adds support for mdadm based RAID arrays. The sample syntax to create RAID0 is:

```
select /dev/sda
mklabel gpt
mkpart primary 0% 100%
set 1 raid on

select /dev/sdb
mklabel gpt
mkpart primary 0% 100%
set 1 raid on

raid0 0 sda1 sdb1

mkfs 0 ext2 -L tmp
```

Supported raid levels are 0, 1, 4, 5, 6, 10