### PR TITLE
80-mkbootable - Bootloader shim install

### DIFF
--- a/provision/initramfs/capabilities/setup-filesystems/80-mkbootable
+++ b/provision/initramfs/capabilities/setup-filesystems/80-mkbootable
@@ -21,20 +21,14 @@ NEWROOT="${NEWROOT:-/newroot}"
 BOOTLOADER="${WWBOOTLOADER:-}"
 
 GRUBINSTALL="${WWGRUBINSTALL:-}"
-
-# Split WWGRUBINSTALLARGS by spaces and parse into an array to make it easier to append arguments and ensure the arguments are
-# correctly quoted.
-IFS=' ' read -r -a GRUBINSTALLARGS <<< "${WWGRUBINSTALLARGS:-}"
+GRUBINSTALLARGS="${WWGRUBINSTALLARGS:-}"
 GRUBVERS="${WWGRUBVERS:-}"
 GRUBMKCONFIG="${WWGRUBMKCONFIG:-}"
 GRUBCFG="${WWGRUBCFG:-}"
 GRUBDEFAULTCONF="${WWGRUBDEFAULTCONF:-/etc/default/grub}"
 
 SHIMINSTALL="${WWSHIMINSTALL:-}"
-
-# Split WWSHIMINSTALLARGS by spaces and parse into an array to make it easier to append arguments and ensure the arguments are
-# correctly quoted.
-IFS=' ' read -r -a SHIMINSTALLARGS <<< "${WWSHIMINSTALLARGS:-}"
+SHIMINSTALLARGS="${WWSHIMINSTALLARGS:-}"
 
 CONSOLE="${WWCONSOLE:-}"
 KARGS="${WWKARGS:-quiet}"
@@ -278,7 +272,7 @@ dev_symlinks() {
     SHIMINSTALL=""
   else
     # If shim-install exists, tell grub2-install not to update boot entries via efibootmgr.
-    GRUBINSTALLARGS+=("--no-nvram")
+    GRUBINSTALLARGS="${GRUBINSTALLARGS} --no-nvram"
   fi
 
   check_and_mount sysfs "${NEWROOT}/sys" sysfs rw,relatime
@@ -308,7 +302,7 @@ dev_symlinks() {
       echo "grub-mkconfig failed."
       exit 2
     fi 
-    if chroot "${NEWROOT}" /usr/bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${GRUBINSTALL}" "${GRUBINSTALLARGS[@]}" "${BOOTLOADER}" >/dev/null; then
+    if chroot "${NEWROOT}" /usr/bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${GRUBINSTALL}" ${GRUBINSTALLARGS} "${BOOTLOADER}" >/dev/null; then
        exit 0
     else
       echo "grub-install failed."
@@ -316,7 +310,7 @@ dev_symlinks() {
     fi
     # If running under EFI, and shim-install exists use it to install Grub into ESP partition.
     if check_efi && [ -n "${SHIMINSTALL}" ]; then
-      if chroot "${NEWROOT}" /usr/bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${SHIMINSTALL}" "${SHIMINSTALLARGS[@]}" --config-file="${GRUBCFG}" >/dev/null; then
+      if chroot "${NEWROOT}" /usr/bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${SHIMINSTALL}" ${SHIMINSTALLARGS} --config-file="${GRUBCFG}" >/dev/null; then
         exit 0
       else
         echo "shim-install failed."

--- a/provision/initramfs/capabilities/setup-filesystems/80-mkbootable
+++ b/provision/initramfs/capabilities/setup-filesystems/80-mkbootable
@@ -137,8 +137,6 @@ find_shim_install() {
     if [ -x "${NEWROOT}/${path}" ]; then
       if chroot "${NEWROOT}" "${path}" --help >/dev/null 2>&1; then
         SHIMINSTALL="${path}"
-        # If shim-install exists, tell grub2-install not to update boot entries via efibootmgr.
-        GRUBINSTALLARGS="${GRUBINSTALLARGS} --no-nvram"
         return 0
       fi
     fi
@@ -270,6 +268,13 @@ dev_symlinks() {
     exit 2
   fi
 
+  if ! find_shim_install "${SHIMINSTALL}"; then
+    SHIMINSTALL=""
+  else
+    # If shim-install exists, tell grub2-install not to update boot entries via efibootmgr.
+    GRUBINSTALLARGS="${GRUBINSTALLARGS} --no-nvram"
+  fi
+
   check_and_mount sysfs "${NEWROOT}/sys" sysfs rw,relatime
   check_and_mount proc "${NEWROOT}/proc" proc rw,relatime
   if check_efi; then
@@ -303,8 +308,8 @@ dev_symlinks() {
       echo "grub-install failed."
       exit 2
     fi
-    # If running under EFI, and shim-install exists use it to install Grub.
-    if check_efi && find_shim_install "${SHIMINSTALL}"; then
+    # If running under EFI, and shim-install exists use it to install Grub into ESP partition.
+    if check_efi && [ -n "${SHIMINSTALL}" ]; then
       if chroot "${NEWROOT}" /usr/bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${SHIMINSTALL}" "${SHIMINSTALLARGS}" --config-file="${GRUBCFG}" >/dev/null; then
         exit 0
       else

--- a/provision/initramfs/capabilities/setup-filesystems/80-mkbootable
+++ b/provision/initramfs/capabilities/setup-filesystems/80-mkbootable
@@ -302,20 +302,17 @@ dev_symlinks() {
       echo "grub-mkconfig failed."
       exit 2
     fi 
-    if chroot "${NEWROOT}" /usr/bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${GRUBINSTALL}" ${GRUBINSTALLARGS} "${BOOTLOADER}" >/dev/null; then
-       exit 0
-    else
+    if ! chroot "${NEWROOT}" /usr/bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${GRUBINSTALL}" ${GRUBINSTALLARGS} "${BOOTLOADER}" >/dev/null; then
       echo "grub-install failed."
       exit 2
     fi
     # If running under EFI, and shim-install exists use it to install Grub into ESP partition.
     if check_efi && [ -n "${SHIMINSTALL}" ]; then
-      if chroot "${NEWROOT}" /usr/bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${SHIMINSTALL}" ${SHIMINSTALLARGS} --config-file="${GRUBCFG}" >/dev/null; then
-        exit 0
-      else
+      if ! chroot "${NEWROOT}" /usr/bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${SHIMINSTALL}" ${SHIMINSTALLARGS} --config-file="${GRUBCFG}" >/dev/null; then
         echo "shim-install failed."
         exit 2
       fi
     fi
   fi
+  exit 0
 }

--- a/provision/initramfs/capabilities/setup-filesystems/80-mkbootable
+++ b/provision/initramfs/capabilities/setup-filesystems/80-mkbootable
@@ -297,7 +297,7 @@ dev_symlinks() {
       echo "grub-mkconfig failed."
       exit 2
     fi 
-    if chroot "${NEWROOT}" /bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${GRUBINSTALL}" "${GRUBINSTALLARGS}" "${BOOTLOADER}" >/dev/null; then
+    if chroot "${NEWROOT}" /usr/bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${GRUBINSTALL}" "${GRUBINSTALLARGS}" "${BOOTLOADER}" >/dev/null; then
        exit 0
     else
       echo "grub-install failed."
@@ -305,7 +305,7 @@ dev_symlinks() {
     fi
     # If running under EFI, and shim-install exists use it to install Grub.
     if check_efi && find_shim_install "${SHIMINSTALL}"; then
-      if chroot "${NEWROOT}" /bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${SHIMINSTALL}" "${SHIMINSTALLARGS}" --config-file="${GRUBCFG}" >/dev/null; then
+      if chroot "${NEWROOT}" /usr/bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${SHIMINSTALL}" "${SHIMINSTALLARGS}" --config-file="${GRUBCFG}" >/dev/null; then
         exit 0
       else
         echo "shim-install failed."

--- a/provision/initramfs/capabilities/setup-filesystems/80-mkbootable
+++ b/provision/initramfs/capabilities/setup-filesystems/80-mkbootable
@@ -6,7 +6,7 @@
 # through Lawrence Berkeley National Laboratory (subject to receipt of any
 # required approvals from the U.S. Dept. of Energy).  All rights reserved.
 #
-# Copyright (c) 2017 Benjamin S. Allen
+# Copyright (c) 2017-2021 Benjamin S. Allen
 
 # Exit on any non-zero exit code
 set -o errexit
@@ -21,10 +21,14 @@ NEWROOT="${NEWROOT:-/newroot}"
 BOOTLOADER="${WWBOOTLOADER:-}"
 
 GRUBINSTALL="${WWGRUBINSTALL:-}"
+GRUBINSTALLARGS="${WWGRUBINSTALLARGS:-}"
 GRUBVERS="${WWGRUBVERS:-}"
 GRUBMKCONFIG="${WWGRUBMKCONFIG:-}"
 GRUBCFG="${WWGRUBCFG:-}"
 GRUBDEFAULTCONF="${WWGRUBDEFAULTCONF:-/etc/default/grub}"
+
+SHIMINSTALL="${WWSHIMINSTALL:-}"
+SHIMINSTALLARGS="${WWSHIMINSTALLARGS:-}"
 
 CONSOLE="${WWCONSOLE:-}"
 KARGS="${WWKARGS:-quiet}"
@@ -113,6 +117,28 @@ find_grub_install() {
     if [ -x "${NEWROOT}/${path}" ]; then
       if chroot "${NEWROOT}" "${path}" --help >/dev/null 2>&1; then
         GRUBINSTALL="${path}"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+find_shim_install() {
+  local PATHS
+
+  if [ -z "${1:-}" ]; then
+    PATHS="/usr/sbin/shim-install /sbin/shim-install"
+  else
+    PATHS="${1}"
+  fi
+
+  for path in ${PATHS}; do
+    if [ -x "${NEWROOT}/${path}" ]; then
+      if chroot "${NEWROOT}" "${path}" --help >/dev/null 2>&1; then
+        SHIMINSTALL="${path}"
+        # If shim-install exists, tell grub2-install not to update boot entries via efibootmgr.
+        GRUBINSTALLARGS="${GRUBINSTALLARGS} --no-nvram"
         return 0
       fi
     fi
@@ -271,11 +297,20 @@ dev_symlinks() {
       echo "grub-mkconfig failed."
       exit 2
     fi 
-    if chroot "${NEWROOT}" /bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${GRUBINSTALL}" "${BOOTLOADER}" >/dev/null; then
+    if chroot "${NEWROOT}" /bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${GRUBINSTALL}" "${GRUBINSTALLARGS}" "${BOOTLOADER}" >/dev/null; then
        exit 0
     else
       echo "grub-install failed."
       exit 2
+    fi
+    # If running under EFI, and shim-install exists use it to install Grub.
+    if check_efi && find_shim_install "${SHIMINSTALL}"; then
+      if chroot "${NEWROOT}" /bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${SHIMINSTALL}" "${SHIMINSTALLARGS}" --config-file="${GRUBCFG}" >/dev/null; then
+        exit 0
+      else
+        echo "shim-install failed."
+        exit 2
+      fi
     fi
   fi
 }

--- a/provision/initramfs/capabilities/setup-filesystems/80-mkbootable
+++ b/provision/initramfs/capabilities/setup-filesystems/80-mkbootable
@@ -21,14 +21,20 @@ NEWROOT="${NEWROOT:-/newroot}"
 BOOTLOADER="${WWBOOTLOADER:-}"
 
 GRUBINSTALL="${WWGRUBINSTALL:-}"
-GRUBINSTALLARGS="${WWGRUBINSTALLARGS:-}"
+
+# Split WWGRUBINSTALLARGS by spaces and parse into an array to make it easier to append arguments and ensure the arguments are
+# correctly quoted.
+IFS=' ' read -r -a GRUBINSTALLARGS <<< "${WWGRUBINSTALLARGS:-}"
 GRUBVERS="${WWGRUBVERS:-}"
 GRUBMKCONFIG="${WWGRUBMKCONFIG:-}"
 GRUBCFG="${WWGRUBCFG:-}"
 GRUBDEFAULTCONF="${WWGRUBDEFAULTCONF:-/etc/default/grub}"
 
 SHIMINSTALL="${WWSHIMINSTALL:-}"
-SHIMINSTALLARGS="${WWSHIMINSTALLARGS:-}"
+
+# Split WWSHIMINSTALLARGS by spaces and parse into an array to make it easier to append arguments and ensure the arguments are
+# correctly quoted.
+IFS=' ' read -r -a SHIMINSTALLARGS <<< "${WWSHIMINSTALLARGS:-}"
 
 CONSOLE="${WWCONSOLE:-}"
 KARGS="${WWKARGS:-quiet}"
@@ -272,7 +278,7 @@ dev_symlinks() {
     SHIMINSTALL=""
   else
     # If shim-install exists, tell grub2-install not to update boot entries via efibootmgr.
-    GRUBINSTALLARGS="${GRUBINSTALLARGS} --no-nvram"
+    GRUBINSTALLARGS+=("--no-nvram")
   fi
 
   check_and_mount sysfs "${NEWROOT}/sys" sysfs rw,relatime
@@ -302,7 +308,7 @@ dev_symlinks() {
       echo "grub-mkconfig failed."
       exit 2
     fi 
-    if chroot "${NEWROOT}" /usr/bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${GRUBINSTALL}" "${GRUBINSTALLARGS}" "${BOOTLOADER}" >/dev/null; then
+    if chroot "${NEWROOT}" /usr/bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${GRUBINSTALL}" "${GRUBINSTALLARGS[@]}" "${BOOTLOADER}" >/dev/null; then
        exit 0
     else
       echo "grub-install failed."
@@ -310,7 +316,7 @@ dev_symlinks() {
     fi
     # If running under EFI, and shim-install exists use it to install Grub into ESP partition.
     if check_efi && [ -n "${SHIMINSTALL}" ]; then
-      if chroot "${NEWROOT}" /usr/bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${SHIMINSTALL}" "${SHIMINSTALLARGS}" --config-file="${GRUBCFG}" >/dev/null; then
+      if chroot "${NEWROOT}" /usr/bin/env PATH=/sbin:/usr/sbin:/bin:/usr/bin "${SHIMINSTALL}" "${SHIMINSTALLARGS[@]}" --config-file="${GRUBCFG}" >/dev/null; then
         exit 0
       else
         echo "shim-install failed."


### PR DESCRIPTION
Suse requires running shim-install to copy the needed grub bits under /boot/efi, and to appropriately add boot entries via efibootmgr

