### PR TITLE
20-filesystems - Extend raid* cmds to allow passing mdadm --create flags

### DIFF
--- a/provision/etc/filesystem/examples/Makefile.am
+++ b/provision/etc/filesystem/examples/Makefile.am
@@ -1,6 +1,6 @@
 confdir = $(sysconfdir)/warewulf/filesystem/examples
 
-dist_conf_DATA = efi_example.cmds efi_nvme_example.cmds gpt_example.cmds gpt_label_example.cmds gpt_raid_example.cmds gpt_uuid_example.cmds hybrid_example.cmds mbr_example.cmds tmpfs_example.cmds
+dist_conf_DATA = efi_example.cmds efi_nvme_example.cmds gpt_example.cmds gpt_label_example.cmds gpt_localboot_raid_example.cmds gpt_raid_example.cmds gpt_uuid_example.cmds hybrid_example.cmds mbr_example.cmds tmpfs_example.cmds
 
 MAINTAINERCLEANFILES = Makefile.in
 

--- a/provision/etc/filesystem/examples/gpt_localboot_raid_example.cmds
+++ b/provision/etc/filesystem/examples/gpt_localboot_raid_example.cmds
@@ -1,0 +1,104 @@
+# Localboot RAID Example with 4 disks, multiple partitions
+
+# Partition each disk sda, sdb, sdc, sdd
+select /dev/sda
+mklabel gpt
+mkpart ESP fat32 1MiB 538MiB
+mkpart primary linux-swap 538MiB 17.7GB
+mkpart primary ext4 17.7GB 155GB
+mkpart primary ext4 155GB 293GB
+mkpart primary ext4 293GB 100%
+name 1 ESP
+name 2 swap
+name 3 var 
+name 4 tmp
+name 5 root
+
+set 1 boot on
+set 2 raid on
+set 3 raid on
+set 4 raid on
+set 5 raid on
+
+select /dev/sdb
+mklabel gpt
+mkpart ESP fat32 1MiB 538MiB
+mkpart primary linux-swap 538MiB 17.7GB
+mkpart primary ext4 17.7GB 155GB
+mkpart primary ext4 155GB 293GB
+mkpart primary ext4 293GB 100%
+name 1 ESP
+name 2 swap
+name 3 var 
+name 4 tmp
+name 5 root
+
+set 1 boot on
+set 2 raid on
+set 3 raid on
+set 4 raid on
+set 5 raid on
+
+select /dev/sdc
+mklabel gpt
+mkpart ESP fat32 1MiB 538MiB
+mkpart primary linux-swap 538MiB 17.7GB
+mkpart primary ext4 17.7GB 155GB
+mkpart primary ext4 155GB 293GB
+mkpart primary ext4 293GB 100%
+name 1 ESP
+name 2 swap
+name 3 var 
+name 4 tmp
+name 5 root
+
+set 1 boot on
+set 2 raid on
+set 3 raid on
+set 4 raid on
+set 5 raid on
+
+select /dev/sdd
+mklabel gpt
+mkpart ESP fat32 1MiB 538MiB
+mkpart primary linux-swap 538MiB 17.7GB
+mkpart primary ext4 17.7GB 155GB
+mkpart primary ext4 155GB 293GB
+mkpart primary ext4 293GB 100%
+name 1 ESP
+name 2 swap
+name 3 var 
+name 4 tmp
+name 5 root
+
+set 1 boot on
+set 2 raid on
+set 3 raid on
+set 4 raid on
+set 5 raid on
+
+# Create RAID1 on /dev/md0 for /boot/efi using metadata format 1.0.
+# Any number of mdadm --create options can be passed this way. Ensure options don't have spaces.
+# Options are differentiated from disks by matching the glob "-?*".
+raid1 0 --metadata=1.0 sda1 sdb1 sdc1 sdd1
+
+# Create RAID10s on /dev/md[1-4] using default options
+raid10 1 sda2 sdb2 sdc2 sdd2
+raid10 2 sda3 sdb3 sdc3 sdd3
+raid10 3 sda4 sdb4 sdc4 sdd4
+raid10 4 sda5 sdb5 sdc5 sdd5
+
+# Format filesystems on /dev/md<n>
+mkfs 0 vfat -n ESP
+mkfs 1 swap
+mkfs 2 ext4 -L var -E nodiscard
+mkfs 3 ext4 -L tmp -E nodiscard
+mkfs 4 ext4 -L root -E nodiscard
+
+# Create fstab entries and mount from /dev/md<n>
+# fstab NUMBER fs_file fs_vfstype fs_mntops fs_freq fs_passno
+fstab 4 / ext4 defaults 0 0
+fstab 1 swap swap defaults 0 0
+fstab 0 /boot/efi vfat defaults 0 0
+fstab 2 /var ext4 defaults 0 0
+fstab 3 /tmp ext4 defaults 0 0

--- a/provision/etc/filesystem/examples/gpt_raid_example.cmds
+++ b/provision/etc/filesystem/examples/gpt_raid_example.cmds
@@ -16,7 +16,10 @@ mklabel gpt
 mkpart primary 0% 100%
 set 1 raid on
 
-# Create RAID5 on /dev/md0: raidX NUMBER PARTITIONS...
+# Create RAID5 on /dev/md0: raidX NUMBER OPTIONS|PARTITIONS... 
+# Can specify a missing device in the array with "missing" or "-".
+# Any number of mdadm --create options can be passed. Ensure options don't have spaces.
+# Options are differentiated from disks by matching the glob "-?*".
 raid5 0 sda1 sdb1 sdc1
 
 # the above command also selects /dev/md, so filesystems can be created:

--- a/provision/initramfs/capabilities/setup-filesystems/20-filesystems
+++ b/provision/initramfs/capabilities/setup-filesystems/20-filesystems
@@ -159,24 +159,41 @@ run_mdadm() {
   fi
 
   shift 2
-  local COUNT="$#"
-  local DEVICES
-  local DEV
+  local COUNT=0
+  local MDADMOPTS
+  local ARG
+  local DEVARGS
+
+  for ARG in "${@:-}"; do
+    case "${ARG}" in
+      -?*)
+        MDADMOPTS="${ARG} ${MDADMOPTS}"
+      ;;
+      *)
+        DEVARGS="${ARG} ${DEVARGS}"
+        COUNT=$((COUNT+1))
+      ;;
+    esac
+  done
 
   if [ ${COUNT} -eq 0 ]; then
     wwlogger "No devices specified for raid${LEVEL} on /dev/md${NUMBER}"
     exit 2
   fi
 
-  local MSG="   * creating raid${LEVEL} on /dev/md${NUMBER} for ${*}"
+  local MSG="   * creating raid${LEVEL} on /dev/md${NUMBER} for ${DEVARGS}"
   msg_gray "${MSG}"
   local MSG_REPEAT=0
 
-  for DEV in ${@:-}; do
+  local DEVICES
+  local DEV
+
+  for DEV in ${DEVARGS}; do
     case "${DEV}" in
       missing|-)
         DEVICES="${DEVICES} missing"
       ;;
+
       *)
         DEV="/dev/${DEV##*/dev/}"
         if [ -x /usr/bin/udevadm ]; then
@@ -199,7 +216,7 @@ run_mdadm() {
 
   {
     # This is ugly but mdadm always asks for confirmation if disks are not empty, so we need /usr/bin/yes
-    (/usr/bin/yes || /bin/true) | /sbin/mdadm --create "/dev/md${NUMBER}" -f "--level=${LEVEL}" --raid-devices=${COUNT} ${DEVICES} >/dev/null 2>&1 && wwsuccess
+    (/usr/bin/yes || /bin/true) | /sbin/mdadm --create "/dev/md${NUMBER}" -f "--level=${LEVEL}" --raid-devices=${COUNT} ${MDADMOPTS} ${DEVICES} >/dev/null 2>&1 && wwsuccess
   } || {
     wwfailure
     exit 2


### PR DESCRIPTION
- raid* filesystem commands can now contain any number of flags that will be passed to mdadm --create. Flags are differentiated from disks by matching the glob "-?*". Flags *cannot* have spaces in this implementation, so use --metadata=1.0 instead of -e 1.0.
- Add extended example for a more complicated RAID setup that is meant for localboot.