### PR TITLE
Add CPU microcode loading using the kernel's early load mechanism

### DIFF
--- a/provision/etc/provision.conf
+++ b/provision/etc/provision.conf
@@ -30,6 +30,13 @@ default transport = http
 # CA Certificate Bundle to include into the initramfs for transport = https
 cacert = /etc/pki/tls/certs/ca-bundle.crt
 
+# If the ucode argument is not set on a node, should the CPU microcode be
+# loaded via the kernel's early load mechanism by default.
+load ucode = no
+
+# Path's to be included in the CPU microcode early load initrd for x86_64. Comma seperated.
+ucode paths x86_64 = /lib/firmware/amd-ucode, /lib/firmware/intel-ucode, /usr/share/microcode_ctl/ucode_with_caveats/intel
+
 # What is the TFTP root directory that should be used to store the
 # network boot images? By default Warewulf will try and find the
 # proper directory. Just add this if it can't locate it.

--- a/provision/lib/Warewulf/Module/Cli/Makefile.am
+++ b/provision/lib/Warewulf/Module/Cli/Makefile.am
@@ -1,6 +1,6 @@
 perlmodsdir = ${PERL_VENDORLIB}/Warewulf/Module/Cli
 
-dist_perlmods_SCRIPTS = Bootstrap.pm Dhcp.pm Provision.pm Vnfs.pm Pxe.pm
+dist_perlmods_SCRIPTS = Bootstrap.pm Dhcp.pm Provision.pm Vnfs.pm Pxe.pm Ucode.pm
 
 MAINTAINERCLEANFILES = Makefile.in
 

--- a/provision/lib/Warewulf/Module/Cli/Ucode.pm
+++ b/provision/lib/Warewulf/Module/Cli/Ucode.pm
@@ -1,0 +1,107 @@
+#
+# Copyright (c) 2001-2003 Gregory M. Kurtzer
+#
+# Copyright (c) 2003-2011, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory (subject to receipt of any
+# required approvals from the U.S. Dept. of Energy).  All rights reserved.
+#
+
+
+
+package Warewulf::Module::Cli::Ucode;
+
+use Warewulf::Logger;
+use Warewulf::DataStore;
+use Warewulf::Util;
+use Warewulf::Provision::Ucode;
+use Getopt::Long;
+
+
+our @ISA = ('Warewulf::Module::Cli');
+
+
+sub
+new()
+{
+    my $proto = shift;
+    my $class = ref($proto) || $proto;
+    my $self = {};
+
+    bless($self, $class);
+
+    return $self;
+}
+
+
+sub
+summary()
+{
+    my $output;
+
+    $output .= "Manage CPU Microcode Initrd Generation";
+
+    return($output);
+}
+
+
+sub
+help()
+{
+    my ($self, $keyword) = @_;
+    my $h;
+
+    $h .= "USAGE:\n";
+    $h .= "     ucode <command>\n";
+    $h .= "\n";
+    $h .= "SUMMARY:\n";
+    $h .= "        Manage CPU Microcode Initrd Generation.\n";
+    $h .= "\n";
+    $h .= "COMMANDS:\n";
+    $h .= "\n";
+    $h .= "         update          Update the ucode initrd\n";
+    $h .= "         help            Show usage information\n";
+    $h .= "\n";
+    $h .= "EXAMPLES:\n";
+    $h .= "\n";
+    $h .= "     Warewulf> ucode update\n";
+    $h .= "\n";
+
+    return($h);
+}
+
+
+sub
+exec()
+{
+    my $self = shift;
+    my $ucode = Warewulf::Provision::Ucode->new();
+
+    @ARGV = ();
+    push(@ARGV, @_);
+
+    Getopt::Long::Configure ("bundling", "nopassthrough");
+
+    $command = shift(@ARGV);
+
+    if (! $command) {
+        &eprint("You must provide a command!\n\n");
+        print $self->help();
+        return();
+    } elsif ($command eq "update") {
+        return($ucode->update());
+    } else {
+        &eprint("Unknown command: $command\n\n");
+        print $self->help();
+        return();
+    }
+}
+
+
+
+1;
+
+
+
+
+
+

--- a/provision/lib/Warewulf/Provision.pm
+++ b/provision/lib/Warewulf/Provision.pm
@@ -265,6 +265,30 @@ ipxeurl()
     return $self->prop("ipxeurl", qr/^([a-zA-Z0-9\.\/\-_\:%\{}\$]+)$/, @val);
 }
 
+=item ucode($bool)
+
+Load CPU microcode via the kernel's early load mechanism for this node.
+
+=cut
+
+sub
+ucode()
+{
+    my ($self, $bool) = @_;
+
+    if (defined($bool)) {
+        if ($bool eq "UNDEF") {
+            $self->del("ucode");
+        } elsif ($bool) {
+            $self->set("ucode", 1);
+        } else {
+            $self->set("ucode", 0);
+        }
+    }
+
+    return $self->get("ucode");
+}
+
 =item fileidadd(@fileids)
 
 Add a file ID or list of file IDs to the current object.

--- a/provision/lib/Warewulf/Provision/Makefile.am
+++ b/provision/lib/Warewulf/Provision/Makefile.am
@@ -2,7 +2,7 @@ SUBDIRS = Dhcp Http
 
 perlmodsdir = ${PERL_VENDORLIB}/Warewulf/Provision
 
-dist_perlmods_SCRIPTS = Dhcp.pm DhcpFactory.pm Pxe.pm Tftp.pm HostsFile.pm Genders.pm Http.pm HttpFactory.pm
+dist_perlmods_SCRIPTS = Dhcp.pm DhcpFactory.pm Pxe.pm Tftp.pm HostsFile.pm Genders.pm Http.pm HttpFactory.pm Ucode.pm
 
 MAINTAINERCLEANFILES = Makefile.in
 

--- a/provision/lib/Warewulf/Provision/Ucode.pm
+++ b/provision/lib/Warewulf/Provision/Ucode.pm
@@ -1,0 +1,124 @@
+
+# Copyright (c) 2001-2003 Gregory M. Kurtzer
+#
+# Copyright (c) 2003-2011, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory (subject to receipt of any
+# required approvals from the U.S. Dept. of Energy).  All rights reserved.
+#
+# Copyright (c) 2022 Benjamin S. Allen
+
+package Warewulf::Provision::Ucode;
+
+use Warewulf::ACVars;
+use Warewulf::Config;
+use Warewulf::File;
+use Warewulf::Logger;
+use Warewulf::Util;
+use File::Basename;
+use File::Path qw(make_path);
+use File::Copy;
+
+our @ISA = ('Warewulf::File');
+
+=head1 NAME
+
+Warewulf::Provision::Ucode - CPU Microcode integration
+
+=head1 ABOUT
+
+
+=head1 SYNOPSIS
+
+    use Warewulf::Provision::Ucode;
+
+    my $obj = Warewulf::Provision::Ucode->new();
+    $obj->Update();
+
+=head1 METHODS
+
+=over 12
+
+=cut
+
+=item new()
+
+The new constructor will create the object that references configuration the
+stores.
+
+=cut
+
+sub
+new($$)
+{
+    my $proto = shift;
+    my $class = ref($proto) || $proto;
+    my $self = {};
+
+    bless($self, $class);
+
+    return $self->init(@_);
+}
+
+sub
+init()
+{
+    my $self = shift;
+
+
+    return($self);
+}
+
+
+=item update()
+
+Initgrate a CPU microcode initrd from the local system for loading via the kernel's microcode early load mechanism.
+
+=cut
+
+sub
+update()
+{
+    my $self = shift;
+    my $statedir = &Warewulf::ACVars::get("statedir");
+    my $config = Warewulf::Config->new("provision.conf");
+    my @ucode_paths_x86_64 = $config->get("ucode paths x86_64");
+    if (! -d "$statedir/warewulf/bootstrap/x86_64") {
+        &eprint("Cannot find $statedir/warewulf/bootstrap/x86_64 directory, not updating x86_64 CPU microcode initrd\n");
+        return();
+    } 
+    &dprint("Checking paths @ucode_paths_x86_64\n");
+
+    my $randstring = &rand_string("12");
+    my $tmpdir = "/var/tmp/wwucode.$randstring";
+    my $x86_tmpdir = "$tmpdir/kernel/x86/microcode";
+    make_path("$x86_tmpdir");
+
+    foreach my $path (@ucode_paths_x86_64) {
+        if (-d "$path") {
+            if (basename($path) eq "intel-ucode") {
+                &dprint("Including $path in GenuineIntel.bin for ucode initrd\n");
+                system("cat $path/* >> $x86_tmpdir/GenuineIntel.bin");
+            } elsif (basename($path) eq "amd-ucode") {
+                &dprint("Including $path in AuthenticAMD.bin for ucode initrd\n");
+                system("cat $path/* >> $x86_tmpdir/AuthenticAMD.bin");
+            } else {
+                &wprint("Only know what todo with paths the end in intel-ucode and amd-ucode, skipping $path\n");
+                next;
+            }
+        } else {
+            &dprint("Cannot find directory $path, skipping\n");
+            next;
+        }
+    }
+    if (-f "$x86_tmpdir/GenuineIntel.bin" || -f "$x86_tmpdir/AuthenticAMD.bin") {
+        &dprint("Creating x86_64 ucode initrd\n");
+        system("(cd $tmpdir; find . | cpio -o --quiet -H newc) > $statedir/warewulf/bootstrap/x86_64/ucode.$randstring");
+        chmod(0644, "$statedir/warewulf/bootstrap/x86_64/ucode.$randstring");
+        move("$statedir/warewulf/bootstrap/x86_64/ucode.$randstring", "$statedir/warewulf/bootstrap/x86_64/ucode");
+    } else {
+        &wprint("Did not generate a GenuineIntel.bin or AuthenticAMD.bin, so skipping creation of new ucode initrd.\n");
+    }
+
+    system("rm -rf $tmpdir");
+    return($self);
+}

--- a/provision/warewulf-provision.spec.in
+++ b/provision/warewulf-provision.spec.in
@@ -133,6 +133,7 @@ fi
 %{perl_vendorlib}/Warewulf/Module/Cli/Bootstrap.pm
 %{perl_vendorlib}/Warewulf/Module/Cli/Provision.pm
 %{perl_vendorlib}/Warewulf/Module/Cli/Vnfs.pm
+%{perl_vendorlib}/Warewulf/Module/Cli/Ucode.pm
 
 
 # ====================

--- a/vnfs/bin/wwbootstrap
+++ b/vnfs/bin/wwbootstrap
@@ -38,6 +38,7 @@ my $opt_output;
 my $opt_config;
 my $opt_name;
 my $opt_kernel = "vmlinuz";
+my $opt_ucode;
 my $kversion;
 my $config;
 my $wwsh_bin;
@@ -50,6 +51,7 @@ my $help = "USAGE: $0 [options] kernel_version
     OPTIONS:
         -c, --chroot    Look into this chroot directory to find the kernel
         -k, --kernel    Look for this file prefix to find the kernel (default: vmlinuz)
+        -u, --ucode     Full path to CPU microcode initrd in CPIO format (default: UNDEF)
         -r, --root      Alias for --chroot
             --config    What configuration file should be used (don't use
                         full path, rather just the relative name as would be
@@ -68,6 +70,7 @@ my $help = "USAGE: $0 [options] kernel_version
         # wwbootstrap --config=testbootstrap 2.6.32-71.el6.x86_64
         # wwbootstrap --chroot=/path/to/chroot 2.6.32-71.el6.x86_64
         # wwbootstrap --output=test-bootstrap.wwbs 2.6.32-71.el6.x86_64
+        # wwbootstrap --ucode=/boot/ucode 2.6.32-71.el6.x86_64
 
 ";
 
@@ -83,6 +86,7 @@ GetOptions(
     'o|output=s'    => \$opt_output,
     'n|name=s'      => \$opt_name,
     'k|kernel=s'    => \$opt_kernel,
+    'u|ucode=s'     => \$opt_ucode,
     'config=s'      => \$opt_config,
 );
 
@@ -158,6 +162,16 @@ if ($opt_kernel) {
     }
 }
 
+if ($opt_ucode) {
+    if ($opt_ucode =~ /^([a-zA-Z0-9_\-\.\/]+)$/) {
+        $opt_ucode = $1;
+        &iprint("Using CPU Microcode initrd: $opt_ucode\n");
+    } else {
+        &eprint("CPU Microcode initrd path contains illegal characters: $opt_kernel\n");
+        exit 1;
+    }
+}
+
 foreach my $dir (split(":", $ENV{"PATH"})) {
     if ($dir =~ /^([a-zA-Z0-9_\-\.\/]+)$/) {
         if (-x "$1/wwsh") {
@@ -167,8 +181,6 @@ foreach my $dir (split(":", $ENV{"PATH"})) {
     }
 }
 
-
-
 mkpath("$tmpdir/initramfs");
 
 if (! -f "$opt_chroot/boot/$opt_kernel-$opt_kversion") {
@@ -176,7 +188,10 @@ if (! -f "$opt_chroot/boot/$opt_kernel-$opt_kversion") {
     exit 1;
 }
 
-
+if ($opt_ucode && ! -f "$opt_ucode") {
+    &eprint("Can't locate the specified CPU microcode initrd: $opt_ucode\n");
+    exit 1;
+}
 
 if ($config->get("drivers")) {
     my @drivers = $config->get("drivers");
@@ -385,6 +400,11 @@ if ($gzip_bin =~ /^([a-zA-Z0-9\-_\/\.]+)$/) {
 # Note, if the kernel isn't a gzip, IO::Uncompress::Gunzip makes a direct copy of the file.
 gunzip "$opt_chroot/boot/$opt_kernel-$opt_kversion" => "$tmpdir/kernel" or die "gunzip of kernel failed: $GunzipError\n";
 
+if ($opt_ucode) {
+    &nprint("Copying the CPU microcode initrd $opt_ucode to bootstrap\n");
+    copy($opt_ucode, "$tmpdir/ucode");
+}
+
 &nprint("Building and compressing bootstrap\n");
 system("(cd $tmpdir; find . | cpio -o --quiet -H newc ) | $gzip_bin $gzip_opts > $output");
 system("rm -rf $tmpdir");
@@ -401,7 +421,11 @@ if ($opt_output) {
     } else {
         $name = $opt_kversion;
     }
-    system("$wwsh_bin bootstrap import $output --name=$name");
+    if ($opt_ucode) {
+        system("$wwsh_bin bootstrap import $output --name=$name --ucode=1");
+    } else {
+        system("$wwsh_bin bootstrap import $output --name=$name");
+    }
     unlink($output);
 }
 


### PR DESCRIPTION
- Add new iPXE configuration to load an initrd named 'ucode' ahead of the Warewulf initrd. This initrd is required to follow the cpio structure as
  defined https://www.kernel.org/doc/html/latest/x86/microcode.html, under "Early load microcode". Only x86_64 is currently supported. Nodes and Bootstraps marked as other architectures will be ignored.
- Adds new subcommand `wwsh ucode update` to generate initrd at $statedir/warewulf/bootstrap/x86_64/ucode from paths specified in provision.conf on the server.
  Typically this requires the microcode_ctl and linux-firmware packages on RHEL, or ucode-intel and ucode-amd packages on SUSE.
- Add two new options in provision.conf:
  - `load ucode` - yes/no boolean that controls the default behavior for the Warewulf install on if the ucode initrd is loaded by default or not. Default is to match existing behavior and not load.
  - `ucode paths x86_64` - Comma separated list of paths to find CPU microcode files. Paths must currently end with amd-ucode or intel-ucode.
- Adds new `wwsh provision set --ucode=<bool>` argument. Adds node-specific control for if the ucode initrd should be loaded or not during boot. Overrides the provision.conf `load ucode` default.
- Adds new `wwbootstrap --ucode=<path to initrd>` argument. When specified a uboot initrd is included with the bootstrap archive. The initrd ucode ends up extracted under `$statedir/warewulf/bootstrap/<id>/ucode`.
  The bootstrap specific ucode initrd is used preferentially over the server's generally installed ucode initrd. This allows for an override and supply specific CPU microcode per bootstrap if needed.
- Adds new `wwsh boostrap import|set --ucode=<bool>` argument to indicate if the bootstrap contains a ucode initrd.