### PR TITLE
WIP: Rev release to 3.10.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
               GITVERSION=$(git show -s --pretty=format:%h)
               DIST=$(rpm --eval '%{dist}')
               yum -y install ~/rpmbuild/RPMS/noarch/\
-              warewulf-common-3.9.0-0.${GITVERSION}${DIST}.noarch.rpm
+              warewulf-common-3.10.0-0.${GITVERSION}${DIST}.noarch.rpm
           name: "Install warewulf-common"
       -
         run:
@@ -134,7 +134,7 @@ jobs:
               GITVERSION=$(git show -s --pretty=format:%h)
               DIST=$(rpm --eval '%{dist}')
               yum -y install ~/rpmbuild/RPMS/noarch/\
-              warewulf-common-3.9.0-0.${GITVERSION}${DIST}.noarch.rpm
+              warewulf-common-3.10.0-0.${GITVERSION}${DIST}.noarch.rpm
           name: "Install warewulf-common"
       -
         run:

--- a/cluster/configure.ac
+++ b/cluster/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT(warewulf-cluster, 3.9.0, warewulf-devel@lbl.gov)
+AC_INIT(warewulf-cluster, 3.10.0, warewulf-devel@lbl.gov)
 AC_CONFIG_SRCDIR([.])
 
 AC_PROG_INSTALL

--- a/common/configure.ac
+++ b/common/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT(warewulf-common, 3.9.0, warewulf-devel@lbl.gov)
+AC_INIT(warewulf-common, 3.10.0, warewulf-devel@lbl.gov)
 AC_CONFIG_SRCDIR([.])
 
 AC_PROG_INSTALL

--- a/ipmi/configure.ac
+++ b/ipmi/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT(warewulf-ipmi, 3.9.0, warewulf-devel@lbl.gov)
+AC_INIT(warewulf-ipmi, 3.10.0, warewulf-devel@lbl.gov)
 AC_CONFIG_SRCDIR([.])
 
 AC_PROG_INSTALL

--- a/provision/configure.ac
+++ b/provision/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT([warewulf-provision], [3.9.0], [warewulf-devel@lbl.gov])
+AC_INIT([warewulf-provision], [3.10.0], [warewulf-devel@lbl.gov])
 AC_CONFIG_SRCDIR([.])
 
 AC_PROG_INSTALL

--- a/vnfs/configure.ac
+++ b/vnfs/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT(warewulf-vnfs, 3.9.0, warewulf-devel@lbl.gov)
+AC_INIT(warewulf-vnfs, 3.10.0, warewulf-devel@lbl.gov)
 AC_CONFIG_SRCDIR([.])
 
 AC_PROG_INSTALL


### PR DESCRIPTION
It's been far too long since we've rev'ed the version of Warewulf3, so doing so now. This PR will be WIP while I test it by using it locally in production for a few weeks.