### PR TITLE
Always load ucode initrd ahead of the warewulf initfs.gz in iPXE

### DIFF
--- a/provision/lib/Warewulf/Provision/Pxe.pm
+++ b/provision/lib/Warewulf/Provision/Pxe.pm
@@ -353,11 +353,12 @@ update()
                         } else {
                             print IPXE "set base http://$node_master_ipaddr/WW/bootstrap\n";
                         }
-                        print IPXE "initrd \${base}/$arch/$bootstrapid/initfs.gz\n";
                         if ($ucode_path) {
                             print IPXE "initrd --name ucode \${base}/$ucode_path\n";
+                            print IPXE "initrd \${base}/$arch/$bootstrapid/initfs.gz\n";
                             print IPXE "kernel \${base}/$arch/$bootstrapid/kernel ro initrd=ucode initrd=initfs.gz wwhostname=$hostname wwtransport=$transport ";
                         } else {
+                            print IPXE "initrd \${base}/$arch/$bootstrapid/initfs.gz\n";
                             print IPXE "kernel \${base}/$arch/$bootstrapid/kernel ro initrd=initfs.gz wwhostname=$hostname wwtransport=$transport ";
                         }
                         print IPXE join(" ", @kargs) . " ";


### PR DESCRIPTION
Appears iPXE and/or the kernel cares about the order that iPXE loads the initrds. In testing the ucode initrd must be loaded first.