### PR TITLE
Drop the hwprefix node attribute and the use of DHCP client identifer for IB

### DIFF
--- a/common/lib/Warewulf/Module/Cli/Node.pm
+++ b/common/lib/Warewulf/Module/Cli/Node.pm
@@ -100,7 +100,6 @@ help()
     $h .= "     -B, --bondmode      Set bonding mode\n";
     $h .= "     -f, --fqdn          Set FQDN of given netdev\n";
     $h .= "     -m, --mtu           Set MTU of given netdev\n";
-    $h .= "     -p, --hwprefix      Specify a prefix for hardware/MAC address of a given netdev\n";
     $h .= "     -c, --cluster       Specify cluster name for this node\n";
     $h .= "         --domain        Specify domain name for this node\n";
     $h .= "     -n, --name          Specify new name for this node\n";
@@ -183,7 +182,6 @@ exec()
     my @opt_hwaddrs;
     my @opt_bonddevs;
     my $opt_bondmode;
-    my $opt_hwprefix;
     my $opt_ipaddr;
     my $opt_netmask;
     my $opt_network;
@@ -224,7 +222,6 @@ exec()
         'netdel'        => \$opt_devremove,
         'netrename=s'   => \$opt_netrename,
         'H|hwaddr=s'    => \@opt_hwaddrs,
-        'p|hwprefix=s'  => \$opt_hwprefix,
         'I|ipaddr=s'    => \$opt_ipaddr,
         'N|network=s'   => \$opt_network,
         'G|gateway=s'   => \$opt_gateway,
@@ -348,7 +345,6 @@ exec()
             printf("%15s: %-16s = %s\n", $nodename, "ENABLED", ($o->enabled()) ? "TRUE" : "FALSE");
             foreach my $devname (sort($o->netdevs_list())) {
                 printf("%15s: %-16s = %s\n", $nodename, "$devname.HWADDR", $o->hwaddr($devname) ? join(',', $o->hwaddr($devname)) : "UNDEF");
-                printf("%15s: %-16s = %s\n", $nodename, "$devname.HWPREFIX", $o->hwprefix($devname) || "UNDEF");
                 printf("%15s: %-16s = %s\n", $nodename, "$devname.IPADDR", $o->ipaddr($devname) || "UNDEF");
                 printf("%15s: %-16s = %s\n", $nodename, "$devname.NETMASK", $o->netmask($devname) || "UNDEF");
                 printf("%15s: %-16s = %s\n", $nodename, "$devname.NETWORK", $o->network($devname) || "UNDEF");
@@ -437,32 +433,6 @@ exec()
                     }
                 } else {
                     &eprint("Can not set HWADDR on more then 1 node!\n");
-                }
-            }
-            if ($opt_hwprefix) {
-                $opt_hwprefix = lc($opt_hwprefix);
-                if ($opt_hwprefix =~ /^((?:[0-9a-f]{2}:){11}[0-9a-f]{2})$/) {
-                    my $show_changes;
-                    foreach my $o ($objSet->get_list()) {
-                        my $nodename = $o->name();
-                        if (! $opt_netdev) {
-                            my @devs = $o->netdevs_list();
-                            if (scalar(@devs) == 1) {
-                                $opt_netdev = shift(@devs);
-                            } else {
-                                &eprint("Option --hwprefix requires the --netdev option for: $nodename\n");
-                                return undef;
-                            }
-                        }
-                        $o->hwprefix($opt_netdev, $1);
-                        $persist_count++;
-                        $show_changes = 1;
-                    }
-                    if ($show_changes) {
-                        push(@changes, sprintf("%8s: %-20s = %s\n", "SET", "$opt_netdev.HWPREFIX", $opt_hwprefix));
-                    }
-                } else {
-                    &eprint("Option 'hwprefix' has invalid characters\n");
                 }
             }
             if ($opt_ipaddr) {

--- a/common/lib/Warewulf/Node.pm
+++ b/common/lib/Warewulf/Node.pm
@@ -316,7 +316,6 @@ canonicalize()
                 bless($n, "Warewulf::Object");
                 $self->add("_ipaddr", $n->get("ipaddr"));
                 $self->add("_hwaddr", $n->get("hwaddr"));
-                $self->add("_hwprefix", $n->get("hwprefix"));
                 $new_netdevs->add($n);
             }
             $self->set("netdevs", $new_netdevs);
@@ -447,7 +446,6 @@ netdel()
     if ($netdev) {
         my @hwaddrs = $netdev->get("hwaddr");
         my $ipaddr = $netdev->get("ipaddr");
-        my $hwprefix = $netdev->get("hwprefix");
         
         &dprint("Object $nodename del netdev $devname\n");
         $self->netdevs()->del($netdev);
@@ -456,9 +454,6 @@ netdel()
         }
         if ($ipaddr) {
             $self->del("_ipaddr", $ipaddr);
-        }
-        if ($hwprefix) {
-            $self->del("_hwprefix", $hwprefix);
         }
     } else {
         &eprint("Object $nodename has no netdev \"$devname\" configured!\n");
@@ -537,37 +532,6 @@ hwaddr()
     return $self->update_netdev_member($devname, "hwaddr", "_hwaddr",
             qr/^((?:[0-9a-f]{2}:){5,7}[0-9a-f]{2})$/,
             ((scalar(@_) >= 3) && (!defined $new_hwaddr[0])) ? ("__UNDEF") : (@new_hwaddr));
-}
-
-=item hwprefix_list()
-
-Shortcut to retrieve a list of all HWADDR Prefixes for this node
-
-=cut
-
-sub
-hwprefix_list()
-{
-    my $self = shift;
-
-    return $self->get("_hwprefix");
-}
-
-=item hwprefix($devname, [ $value ])
-
-Get or set the hwaddr prefix for the network device named I<$devname>.
-
-=cut
-
-sub
-hwprefix()
-{
-    my ($self, $devname, $new_hwprefix) = @_;
-
-    return $self->update_netdev_member($devname, "hwprefix", "_hwprefix",
-            qr/^((?:[0-9a-f]{2}:){11}[0-9a-f]{2})$/,
-            ((scalar(@_) >= 3) && (!defined($new_hwprefix))) ? ("__UNDEF")
-             : ((defined($new_hwprefix)) ? (lc($new_hwprefix)) : (undef)));
 }
 
 =item ipaddr_list()

--- a/common/share/wwsh.1
+++ b/common/share/wwsh.1
@@ -512,11 +512,6 @@ Set FQDN of given netdev.
 Set MTU of given netdev.
 .RE
 .PP
-.B \-p, \-\-hwprefix    
-.RS 4
-Specify a prefix for hardware/MAC address of a given netdev.
-.RE
-.PP
 .B \-c, \-\-cluster     
 .RS 4
 Specify cluster name for this node.

--- a/provision/initramfs/init
+++ b/provision/initramfs/init
@@ -430,9 +430,9 @@ fi
 if [ ! -f /tmp/wwdev ]; then
     for i in `echo /sys/class/net/* | xargs -n1 /usr/bin/basename | grep -v lo`; do
         HWADDR=`cat /sys/class/net/$i/address`
-        # Use GUID if IB
+        # Calculate shortened HWADDR from GUID if IB
         if [ ${#HWADDR} -eq 59 ]; then
-            HWADDR=`expr substr $HWADDR 37 23`
+            HWADDR=`expr substr $WWINIT_HWADDR 37 8`:`expr substr $WWINIT_HWADDR 52 8`
         fi
         if [ $HWADDR == $WWHWADDR ]; then
             if ifup $i $WWHWADDR $WWNETDEV; then
@@ -447,9 +447,9 @@ fi
 if [ ! -f /tmp/wwdev ]; then
     for i in `echo /sys/class/net/* | xargs -n1 /usr/bin/basename | grep -v lo`; do
         HWADDR=`cat /sys/class/net/$i/address`
-        # Use GUID if IB
+        # Calculate shortened HWADDR from GUID if IB
         if [ ${#HWADDR} -eq 59 ]; then
-            HWADDR=`expr substr $HWADDR 37 23`
+            HWADDR=`expr substr $WWINIT_HWADDR 37 8`:`expr substr $WWINIT_HWADDR 52 8`
         fi
         if ifup $i $HWADDR $WWNETDEV; then
             echo "$i" > /tmp/wwdev
@@ -478,7 +478,7 @@ msg_white "Probing for HW Address: "
 if [ -f "/sys/class/net/$NETDEV/address" ]; then
     WWINIT_HWADDR=`cat /sys/class/net/$NETDEV/address`
     if [ ${#WWINIT_HWADDR} -eq 59 ]; then
-        WWINIT_HWADDR=`expr substr $WWINIT_HWADDR 37 23`
+        WWINIT_HWADDR=`expr substr $WWINIT_HWADDR 37 8`:`expr substr $WWINIT_HWADDR 52 8`
     fi
     msg_gray "($WWINIT_HWADDR)"
     wwsuccess

--- a/provision/lib/Warewulf/Provision/Dhcp/Dnsmasq.pm
+++ b/provision/lib/Warewulf/Provision/Dhcp/Dnsmasq.pm
@@ -234,7 +234,6 @@ persist()
 
             foreach my $devname ($n->netdevs_list()) {
                 my @hwaddrs = $n->hwaddr($devname);
-                my $hwprefix = $n->hwprefix($devname);
                 my $node_ipaddr = $n->ipaddr($devname);
                 my $node_netmask = $n->netmask($devname) || $netmask;
                 my $node_gateway = $n->gateway($devname);

--- a/provision/lib/Warewulf/Provision/Dhcp/Isc.pm
+++ b/provision/lib/Warewulf/Provision/Dhcp/Isc.pm
@@ -264,7 +264,6 @@ persist()
 
             foreach my $devname ($n->netdevs_list()) {
                 my @hwaddrs = $n->hwaddr($devname);
-                my $hwprefix = $n->hwprefix($devname);
                 my $mtu = $n->mtu($devname);
                 my $node_ipaddr = $n->ipaddr($devname);
                 my $node_netmask = $n->netmask($devname) || $netmask;
@@ -346,11 +345,7 @@ persist()
                         if ($domain) {
                             $dhcpd_contents .= "      option domain-name \"$domain\";\n";
                         }
-                        if ($devname =~ /ib\d+/ && $hwprefix) {
-                            $dhcpd_contents .= "      option dhcp-client-identifier = $hwprefix:$hwaddr;\n";
-                        } else {
-                            $dhcpd_contents .= "      hardware ethernet $hwaddr;\n";
-                        }
+                        $dhcpd_contents .= "      hardware ethernet $hwaddr;\n";
                         if ($mtu) {
                             $dhcpd_contents .= "      option interface-mtu $mtu;\n";
                         }


### PR DESCRIPTION
It seems with UEFI based PXE booting over IB, both UEFI and iPXE no longer attempt to use the DHCP client identifier. While its technically more correct to use the GUID of an IB adapter, it seems its no longer practical to do so.

1. Dropping the use of hwprefix
2. Updating init in the initramfs to calculate the 48-bit HWADDR from the the 20 byte address instead of the 64-bit GUID.

From

```
HWADDR=`expr substr $HWADDR 37 23`
```

To

```
HWADDR=`expr substr $HWADDR 37 8`:`expr substr $HWADDR 52 8`
```
