### PR TITLE
Add openEuler 22.03 support

### DIFF
--- a/common/lib/Warewulf/System/Euler.pm
+++ b/common/lib/Warewulf/System/Euler.pm
@@ -1,0 +1,168 @@
+# Copyright (c) 2001-2003 Gregory M. Kurtzer
+#
+# Copyright (c) 2003-2011, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory (subject to receipt of any
+# required approvals from the U.S. Dept. of Energy).  All rights reserved.
+#
+#
+# $Id: Rhel.pm 1969 2016-03-25 18:49:30Z bsallen $
+#
+
+package Warewulf::System::Euler;
+
+use Warewulf::System;
+use Warewulf::Logger;
+
+our @ISA = ('Warewulf::System');
+
+=head1 NAME
+
+Warewulf::Euler - Warewulf's general object instance object interface.
+
+=head1 ABOUT
+
+
+=head1 SYNOPSIS
+
+    use Warewulf::System::Euler;
+
+    my $obj = Warewulf::System::Euler->new();
+
+
+=head1 METHODS
+
+=over 12
+
+=cut
+
+=item new()
+
+The new constructor will create the object that references configuration the
+stores.
+
+=cut
+
+sub
+new($$)
+{
+    my $proto = shift;
+    my $class = ref($proto) || $proto;
+    my $self = {};
+
+    bless($self, $class);
+
+    return $self;
+}
+
+
+=item service($name, $command)
+
+Run a command on a service script (e.g. /etc/init.d/service restart).
+
+=cut
+
+sub
+service($$$)
+{
+    my ($self, $service, $command) = @_;
+
+    &dprint("Running service command: $service, $command\n");
+
+    if ( -x "/bin/systemctl" ) {
+        system("/bin/systemctl $command $service.service") == 0 and return(1);
+    } elsif (-x "/etc/init.d/$service") {
+        $self->{"OUTPUT"} = ();
+        open(SERVICE, "/etc/init.d/$service $command 2>&1|");
+        while(<SERVICE>) {
+            $self->{"OUTPUT"} .= $_;
+        }
+        chomp($self->{"OUTPUT"});
+        if (close SERVICE) {
+            &dprint("Service command ran successfully\n");
+            return(1);
+        } else {
+            &dprint("Error running: /etc/init.d/$service $command\n");
+        }
+    } 
+	if ($self->{"OUTPUT"}) {
+        chomp($self->{"OUTPUT"});
+        if (close SERVICE) {
+            &dprint("Service command ran successfully\n");
+            return(1);
+        } else {
+            &dprint("Error running: /usr/bin/systemctl $command $service\n");
+        } 
+    }
+    return();
+}
+
+
+
+
+=item chkconfig($name, $command)
+
+Enable a service script to be enabled or disabled at boot (e.g.
+/sbin/chkconfig service on).
+
+=cut
+
+sub
+chkconfig($$$)
+{
+    my ($self, $service, $command) = @_;
+
+    if ( -x "/bin/systemctl" ) {
+        system("/bin/systemctl enable $service.service");
+    } elsif (-x "/sbin/chkconfig") {
+        open(CHKCONFIG, "/sbin/chkconfig $service $command 2>&1|");
+        while(<CHKCONFIG>) {
+            $self->{"OUTPUT"} .= $_;
+        }
+        if (defined($self->{"OUTPUT"})) {
+            chomp($self->{"OUTPUT"});
+        }
+        if (close CHKCONFIG) {
+            &dprint("Chkconfig command ran successfully\n");
+            return(1);
+        } else {
+            &dprint("Error running: /sbin/chkconfig $service $command\n");
+        }
+    }
+    return();
+}
+
+
+=item output()
+
+return the output cache on a command
+
+=cut
+
+sub
+output($)
+{
+    my $self = shift;
+
+    return(defined($self->{"OUTPUT"}) ? $self->{"OUTPUT"} : "");
+}
+
+
+
+=back
+
+=head1 SEE ALSO
+
+Warewulf::Object
+
+=head1 COPYRIGHT
+
+Copyright (c) 2001-2003 Gregory M. Kurtzer
+
+Copyright (c) 2003-2011, The Regents of the University of California,
+through Lawrence Berkeley National Laboratory (subject to receipt of any
+required approvals from the U.S. Dept. of Energy).  All rights reserved.
+
+=cut
+
+
+1;

--- a/common/lib/Warewulf/System/Makefile.am
+++ b/common/lib/Warewulf/System/Makefile.am
@@ -1,6 +1,6 @@
 perlmodsdir = ${PERL_VENDORLIB}/Warewulf/System
 
-dist_perlmods_SCRIPTS = Rhel.pm Deb.pm Suse.pm
+dist_perlmods_SCRIPTS = Rhel.pm Deb.pm Suse.pm Euler.pm
 
 MAINTAINERCLEANFILES = Makefile.in
 

--- a/common/lib/Warewulf/SystemFactory.pm
+++ b/common/lib/Warewulf/SystemFactory.pm
@@ -50,6 +50,8 @@ new($$)
         $type = "unsupported";
         if (-f "/etc/redhat-release") {
             $type = "rhel";
+        } elsif (-f "/etc/openEuler-release") {
+            $type = "Euler";
         } elsif (-f "/etc/SuSE-release") {
             $type = "Suse";
         } elsif ( -f "/etc/debian_version" ) {

--- a/vnfs/libexec/wwmkchroot/Makefile.am
+++ b/vnfs/libexec/wwmkchroot/Makefile.am
@@ -1,6 +1,6 @@
 wwmkchrootdir = $(libexecdir)/warewulf/wwmkchroot
 
-dist_wwmkchroot_SCRIPTS = centos-6.tmpl centos-7.tmpl include-rhel sl-7.tmpl functions include-deb debian-8.tmpl debian7-32.tmpl debian7-64.tmpl golden-system.tmpl include-suse opensuse-42.3.tmpl opensuse-15.3.tmpl opensuse-tumbleweed.tmpl sles-12.tmpl sle-15.tmpl include-ubuntu ubuntu-16.04.tmpl ubuntu-18.04.tmpl centos-8.tmpl sles-15.tmpl
+dist_wwmkchroot_SCRIPTS = centos-6.tmpl centos-7.tmpl include-rhel sl-7.tmpl functions include-deb debian-8.tmpl debian7-32.tmpl debian7-64.tmpl golden-system.tmpl include-suse opensuse-42.3.tmpl opensuse-15.3.tmpl opensuse-tumbleweed.tmpl sles-12.tmpl sle-15.tmpl include-ubuntu ubuntu-16.04.tmpl ubuntu-18.04.tmpl centos-8.tmpl sles-15.tmpl include-openEuler openeuler-22.03.tmpl
  
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/vnfs/libexec/wwmkchroot/include-openEuler
+++ b/vnfs/libexec/wwmkchroot/include-openEuler
@@ -46,6 +46,7 @@ prechroot() {
 
     > $CHROOTDIR/$YUM_CONF
     echo "[main]" >> $CHROOTDIR/$YUM_CONF
+    echo "install_weak_deps=1" >> $CHROOTDIR/$YUM_CONF
     echo 'cachedir=/var/cache/yum/$basearch/$releasever' >> $CHROOTDIR/$YUM_CONF
     echo "keepcache=0" >> $CHROOTDIR/$YUM_CONF
     echo "debuglevel=2" >> $CHROOTDIR/$YUM_CONF

--- a/vnfs/libexec/wwmkchroot/include-openEuler
+++ b/vnfs/libexec/wwmkchroot/include-openEuler
@@ -1,0 +1,107 @@
+vnfs/libexec/wwmkchroot/include-openEulerREPO_NAME="os-base"
+YUM_CONF="/root/yum-ww.conf"
+YUM_CMD="yum -c $CHROOTDIR/$YUM_CONF --installroot $CHROOTDIR -y"
+
+distro_check() {
+    if ! rpm -q yum >/dev/null 2>&1 ; then
+        echo "ERROR: Could not query RPM for YUM"
+        return 1
+    fi
+    return 0
+}
+
+set_overlay() {
+    if [ ! -d "$CHROOTDIR" -o ! -x "$CHROOTDIR/sbin/init" ]; then
+        echo "ERROR: This is an overlay that must work on an existing chroot!"
+        return 1
+    fi
+    if [ ! -f "$CHROOTDIR/etc/openEuler-release" ]; then
+        echo "ERROR: This must be a openEuler compatible chroot!"
+        return 1
+    fi
+    PKGR_CMD="$YUM_CMD install $PKGLIST"
+    return 0
+}
+
+prechroot() {
+    if [ -n "$OS_MIRROR" ]; then
+        YUM_MIRROR="$OS_MIRROR"
+    fi
+    if [[ -z "$YUM_MIRROR" && -z "$INSTALL_ISO" ]]; then
+        echo "ERROR: You must define the \$YUM_MIRROR variable in the template"
+        cleanup
+        return 1
+    fi
+
+    VERSION=`rpm -qf /etc/openEuler-release  --qf '%{VERSION}\n'`
+
+    mkdir -p $CHROOTDIR
+    mkdir -p $CHROOTDIR/etc
+
+    cp -rap /etc/yum.conf /etc/yum.repos.d $CHROOTDIR/etc
+    sed -i -e "s/\$releasever/$VERSION/g" `find $CHROOTDIR/etc/yum* -type f`
+
+    YUM_CONF_DIRNAME=`dirname $YUM_CONF`
+    mkdir -m 0755 -p $CHROOTDIR/$YUM_CONF_DIRNAME
+
+    > $CHROOTDIR/$YUM_CONF
+    echo "[main]" >> $CHROOTDIR/$YUM_CONF
+    echo 'cachedir=/var/cache/yum/$basearch/$releasever' >> $CHROOTDIR/$YUM_CONF
+    echo "keepcache=0" >> $CHROOTDIR/$YUM_CONF
+    echo "debuglevel=2" >> $CHROOTDIR/$YUM_CONF
+    echo "logfile=/var/log/yum.log" >> $CHROOTDIR/$YUM_CONF
+    echo "exactarch=1" >> $CHROOTDIR/$YUM_CONF
+    echo "obsoletes=1" >> $CHROOTDIR/$YUM_CONF
+    echo "gpgcheck=0" >> $CHROOTDIR/$YUM_CONF
+    echo "plugins=1" >> $CHROOTDIR/$YUM_CONF
+    echo "reposdir=0" >> $CHROOTDIR/$YUM_CONF
+    echo "" >> $CHROOTDIR/$YUM_CONF
+
+    if [ -z "$INSTALL_ISO" ]; then
+        echo "[$REPO_NAME]" >> $CHROOTDIR/$YUM_CONF
+        echo 'name=Linux $releasever - $basearch' >> $CHROOTDIR/$YUM_CONF
+        echo "baseurl=$YUM_MIRROR" >> $CHROOTDIR/$YUM_CONF
+        echo "enabled=1" >> $CHROOTDIR/$YUM_CONF
+        echo "gpgcheck=0" >> $CHROOTDIR/$YUM_CONF
+    else
+        for i in `ls -d $MEDIA_MOUNTPATH.*`; do
+            if [ -z "$INSTALLDIRS" ]; then
+                if [ -d $i/repodata ]; then
+                    # RHEL 6.x
+                    INSTALLDIRS="file://$i"
+                elif [ -d $i/Server/repodata ]; then
+                    # RHEL 5.x
+                    INSTALLDIRS="file://$i/Server"
+                fi
+            else
+                INSTALLDIRS="$INSTALLDIRS,file://$i"
+            fi
+        done
+        echo "[$REPO_NAME]" >> $CHROOTDIR/$YUM_CONF
+        echo 'name=Linux $releasever - $basearch' >> $CHROOTDIR/$YUM_CONF
+        echo "baseurl=$INSTALLDIRS" >> $CHROOTDIR/$YUM_CONF
+        echo "enabled=1" >> $CHROOTDIR/$YUM_CONF
+        echo "gpgcheck=0" >> $CHROOTDIR/$YUM_CONF
+
+        YUM_MIRROR=$INSTALLDIRS
+    fi
+    PKGR_CMD="$YUM_CMD install $PKGLIST"
+    return 0
+}
+
+postchroot() {
+    touch $CHROOTDIR/fastboot
+
+    NETFILE=$CHROOTDIR/etc/sysconfig/network-scripts/network-functions
+    if [ -f $NETFILE ]; then
+        if grep -q 'rename_device' $NETFILE && ! grep -q 'rename_device() { return 0; }' $NETFILE; then
+            echo "" >> $NETFILE
+            echo "# This is a kludge added by Warewulf so devices don't get renamed (broke things with IB)" >> $NETFILE
+            echo "rename_device() { return 0; }" >> $NETFILE
+        fi
+    fi
+    return 0
+}
+
+
+# vim:filetype=sh:syntax=sh:expandtab:ts=4:sw=4:

--- a/vnfs/libexec/wwmkchroot/openeuler-22.03.tmpl
+++ b/vnfs/libexec/wwmkchroot/openeuler-22.03.tmpl
@@ -1,0 +1,33 @@
+#DESC: openEuler 22.03
+
+# The general openEUler include has all of the necessary functions, but requires
+# some basic variables specific to each chroot type to be defined.
+
+# Use DNF as the package manager
+PKG_MGR=dnf
+EXTRA_ARGS="--releasever=22.03"
+PLATFORMID="platform:oe2203"
+
+# Uncomment to disable GPG checks on added repos
+# REPO_NOGPGCHECK=1
+
+. include-openEuler
+
+# Define the location of the YUM repository
+if [ -z "$YUM_MIRROR" ]; then
+    if [ -z "$YUM_MIRROR_BASE" ]; then
+        YUM_MIRROR_BASE="http://repo.openeuler.org"
+    fi
+    YUM_MIRROR="${YUM_MIRROR_BASE}/openEuler-22.03-LTS/OS/\$basearch/os","${YUM_MIRROR_BASE}/openEuler-22.03-LTS/everything/\$basearch","${YUM_MIRROR_BASE}/openEuler-22.03-LTS/EPOL/main/\$basearch"
+fi
+
+# Install only what is necessary/specific for this distribution
+PKGLIST="basesystem bash chkconfig coreutils e2fsprogs ethtool
+    filesystem findutils gawk grep initscripts iproute iputils
+    net-tools nfs-utils pam psmisc rsync sed setup
+    shadow rsyslog tzdata util-linux words
+    zlib tar less gzip which util-linux openssh-clients
+    openssh-server dhcp pciutils vim-minimal
+    strace cronie crontabs cpio wget openEuler-release hostname grub2-common glibc-all-langpacks"
+
+# vim:filetype=sh:syntax=sh:expandtab:ts=4:sw=4:


### PR DESCRIPTION
openEuler is an open source platform developed and operated by OpenAtom Foundation. Its unified and open OS supports multiple processor architectures, helping promote a more robust software and hardware ecosystem through joint efforts of the community(https://www.openeuler.org/en). 

This patch add openEuler supported.See also:

[1] https://github.com/openhpc/ohpc/commit/7f063606fc34b5199e9e951b3bfd6be41a795f1b
[2] https://github.com/openhpc/ohpc/commit/18ff07eaeea4410d3146d507d340c7aa4950a2cf