### PR TITLE
Make Build reproducible

### DIFF
--- a/ipmi/initramfs/Makefile.am
+++ b/ipmi/initramfs/Makefile.am
@@ -9,7 +9,7 @@ IPMITOOL_SOURCE = $(top_srcdir)/3rd_party/BSD/ipmitool-$(IPMITOOL_VERSION).tar.b
 
 ipmitool:
 	@ if [ -n "@local_ipmitool_path@" -a -f "@local_ipmitool_path@" ]; then \
-            cp "@local_ipmitool_path@" ipmitool; \
+            echo "Detected local install of ipmitool. Bypassing the build process." ;\
 	else \
 	    if [ ! -d "_work/ipmitool/ipmitool-$(IPMITOOL_VERSION)" ]; then \
 	        echo "Preparing to build ipmitool" ;\
@@ -19,22 +19,19 @@ ipmitool:
 	    if [ ! -f "_work/ipmitool/ipmitool-$(IPMITOOL_VERSION)/src/ipmitool" ]; then \
 	        echo "Building ipmitool" ;\
 		if [ -f "/usr/lib/rpm/config.guess" ]; then \
-			cp /usr/lib/rpm/config.guess _work/ipmitool/ipmitool-$(IPMITOOL_VERSION) ;\
+			cp -a /usr/lib/rpm/config.guess _work/ipmitool/ipmitool-$(IPMITOOL_VERSION) ;\
 		fi; \
 		if [ -f "/usr/lib/rpm/config.sub" ]; then \
-			cp /usr/lib/rpm/config.sub _work/ipmitool/ipmitool-$(IPMITOOL_VERSION) ;\
+			cp -a /usr/lib/rpm/config.sub _work/ipmitool/ipmitool-$(IPMITOOL_VERSION) ;\
 		fi; \
 	        cd _work/ipmitool/ipmitool-$(IPMITOOL_VERSION) ;\
 	        ./configure --enable-static --disable-ipmishell ;\
 	        $(MAKE) LDFLAGS=-static ;\
 		cd -;\
 	    fi; \
-	    if [ ! -f "unionfs" ]; then \
-	        cp -a _work/ipmitool/ipmitool-$(IPMITOOL_VERSION)/src/ipmitool ipmitool ;\
-	    fi \
 	fi
 
-
+# Preserve time stamps of archived files for build reproducibility
 rootfs: ipmitool
 	rm -rf rootfs
 	mkdir rootfs
@@ -43,14 +40,20 @@ rootfs: ipmitool
 	mkdir rootfs/lib64
 	mkdir -p rootfs/warewulf/provision/
 	chmod -R u+w rootfs/
-	cp -a ipmitool rootfs/sbin/
-	find rootfs -type f -perm -o+x  -print | xargs ldd | grep "=>" | awk '{print $$3}' | grep "^/" | sort | uniq | while read i; do cp -L --parents $$i rootfs/; done
+	if [ -n "@local_ipmitool_path@" -a -f "@local_ipmitool_path@" ]; then \
+            cp -av "@local_ipmitool_path@" rootfs/sbin/; \
+	else \
+            cp -v _work/ipmitool/ipmitool-$(IPMITOOL_VERSION)/src/ipmitool rootfs/sbin/ ;\
+            touch -r 10-ipmiconfig rootfs/sbin/ipmitool; \
+	fi
+	find rootfs -type f -perm -o+x  -print | xargs ldd | grep "=>" | awk '{print $$3}' | grep "^/" | sort | uniq | while read i; do cp -avL --parents $$i rootfs/; done
 	chmod -R +w rootfs/
-	find rootfs -type f -perm -o+x -print | xargs strip -g
-	install -m 755 $(srcdir)/10-ipmiconfig rootfs/warewulf/provision/10-ipmiconfig
+	find rootfs -type f -perm -o+x -print | xargs strip -pg
+	install -p -m 755 $(srcdir)/10-ipmiconfig rootfs/warewulf/provision/10-ipmiconfig
 
 capability.cpio: rootfs
-	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
+	find rootfs/ -type d | xargs touch -r $(srcdir)/10-ipmiconfig
+	cd rootfs/; find . | cpio -o -H newc --reproducible -F ../capability.cpio
 
 install-data-local: capability.cpio
 	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)
@@ -58,7 +61,7 @@ install-data-local: capability.cpio
 	install -m 644 capability.cpio $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities/setup-ipmi
 	@ if [ -z "@local_ipmitool_path@" -o ! -f "@local_ipmitool_path@" ]; then \
 	   install -d -m 755 $(DESTDIR)/$(WAREWULF_LIBEXECDIR)/warewulf; \
-	   install -m 755 ipmitool $(DESTDIR)/$(WAREWULF_LIBEXECDIR)/warewulf; \
+	   install -m 755 rootfs/sbin/ipmitool $(DESTDIR)/$(WAREWULF_LIBEXECDIR)/warewulf; \
         fi
 
 uninstall-local:

--- a/provision/initramfs/Makefile.am
+++ b/provision/initramfs/Makefile.am
@@ -147,6 +147,7 @@ kmod:
 		echo "Detected local install of kmod." ;\
 	fi
 
+# Preserve time stamps of archived files for build reproducibility
 rootfs: busybox e2fsprogs xfsprogs libarchive parted curl mdadm kmod
 	rm -rf rootfs
 	mkdir rootfs
@@ -171,6 +172,7 @@ rootfs: busybox e2fsprogs xfsprogs libarchive parted curl mdadm kmod
 		cp -av "@local_busybox_path@" rootfs/bin/busybox ;\
 	else \
 		cp -av _work/$(BUSYBOX_DIR)/_install/* rootfs/ ;\
+	        find rootfs/ | xargs touch -r devs.cpio; \
 	fi
 	if [ ! -L rootfs/bin/sh ]; then \
 		for i in `find rootfs/usr/bin -type l -a -lname "*busybox"`; do \
@@ -187,8 +189,9 @@ rootfs: busybox e2fsprogs xfsprogs libarchive parted curl mdadm kmod
 		cp -av "@local_e2fsprogs_path@" rootfs/sbin/mkfs.ext4 ;\
 		cp -av "/etc/mke2fs.conf" rootfs/etc/mke2fs.conf ;\
 	else \
-		cp -av _work/$(E2FSPROGS_DIR)/misc/mke2fs rootfs/sbin/mkfs.ext4 ;\
-		cp -av _work/$(E2FSPROGS_DIR)/misc/mke2fs.conf rootfs/etc/mke2fs.conf ;\
+		cp -v _work/$(E2FSPROGS_DIR)/misc/mke2fs rootfs/sbin/mkfs.ext4 ;\
+		cp -v _work/$(E2FSPROGS_DIR)/misc/mke2fs.conf rootfs/etc/mke2fs.conf;\
+	        touch -r devs.cpio rootfs/sbin/mkfs.ext4 rootfs/etc/mke2fs.conf; \
 	fi
 	ln -s mkfs.ext4 rootfs/sbin/mkfs.ext3
 	if [ -n "@local_xfsprogs_path@" -a -f "@local_xfsprogs_path@" ]; then \
@@ -197,7 +200,8 @@ rootfs: busybox e2fsprogs xfsprogs libarchive parted curl mdadm kmod
 	if [ -n "@local_libarchive_path@" -a -f "@local_libarchive_path@" ]; then \
 		cp -av "@local_libarchive_path@" rootfs/bin/bsdtar; \
 	else \
-		cp -av _work/$(LIBARCHIVE_DIR)/bsdtar rootfs/bin/bsdtar; \
+		cp -v _work/$(LIBARCHIVE_DIR)/bsdtar rootfs/bin/bsdtar; \
+	        touch -r devs.cpio rootfs/bin/bsdtar; \
 	fi
 	if [ -n "@local_parted_path@" -a -f "@local_parted_path@" -a \
 	  -n "@local_partprobe_path@" -a -f "@local_partprobe_path@" ]; then \
@@ -207,11 +211,13 @@ rootfs: busybox e2fsprogs xfsprogs libarchive parted curl mdadm kmod
 	else \
 		rm -f rootfs/usr/sbin/partprobe; \
 		$(MAKE) -C _work/$(PARTED_DIR)/ DESTDIR=`pwd`/rootfs install; \
+		touch -r devs.cpio rootfs/usr/sbin/partprobe; \
 	fi
 	if [ -n "@local_curl_path@" -a -f "@local_curl_path@" ]; then \
 		cp -av "@local_curl_path@" rootfs/bin/curl; \
 	else \
-		cp -av _work/$(CURL_DIR)/src/curl rootfs/bin/curl; \
+		cp -v _work/$(CURL_DIR)/src/curl rootfs/bin/curl; \
+	        touch -r devs.cpio rootfs/bin/curl; \
 	fi
 	if [ -n "@local_mdadm_path@" -a -f "@local_mdadm_path@" ]; then \
 		cp -av @local_mdadm_path@ rootfs/sbin/mdadm; \
@@ -227,27 +233,29 @@ rootfs: busybox e2fsprogs xfsprogs libarchive parted curl mdadm kmod
 	fi ;\
 	cp -L --parents /lib*/ld-linux* rootfs/
 	cp -L --parents /lib*/libnss_dns* rootfs/
-	find rootfs -type f -perm -o+x -print | grep -v ld-linux | xargs ldd | grep "=>" | awk '{print $$3}' | grep "^/" | sort | uniq | while read i; do cp -L --parents $$i rootfs/ && chmod 755 rootfs/$$i; done
+	find rootfs -type f -perm -o+x -print | grep -v ld-linux | xargs ldd | grep "=>" | awk '{print $$3}' | grep "^/" | sort | uniq | while read i; do cp -avL --parents $$i rootfs/ && chmod 755 rootfs/$$i; done
 	rm -f rootfs/linuxrc rootfs/lib64/*.la rootfs/lib/*.la rootfs/usr/lib64/*.la rootfs/usr/lib/*.la
 	rm -rf rootfs/usr/share rootfs/usr/include rootfs/usr/lib/pkgconfig
 	find -type d \! -perm -u=w -exec chmod u+w {} \;
-	find rootfs -type f -perm -o+x -print | xargs strip -g
+	find rootfs -type f -perm -o+x -print | xargs strip -pg
 
-	install -m 755 $(srcdir)/init rootfs/init
-	install -m 755 $(srcdir)/functions rootfs/etc/functions
-	install -m 755 $(srcdir)/dhcp-script rootfs/sbin/
-	install -m 755 $(srcdir)/detect rootfs/sbin/
-	install -m 755 $(srcdir)/transporthandler rootfs/sbin/
-	install -m 755 $(srcdir)/provisionhandler rootfs/sbin/
-	install -m 755 $(srcdir)/wwlogger rootfs/sbin/
+	install -p -m 755 $(srcdir)/init rootfs/init
+	install -p -m 755 $(srcdir)/functions rootfs/etc/functions
+	install -p -m 755 $(srcdir)/dhcp-script rootfs/sbin/
+	install -p -m 755 $(srcdir)/detect rootfs/sbin/
+	install -p -m 755 $(srcdir)/transporthandler rootfs/sbin/
+	install -p -m 755 $(srcdir)/provisionhandler rootfs/sbin/
+	install -p -m 755 $(srcdir)/wwlogger rootfs/sbin/
 	ln -s transporthandler rootfs/sbin/wwgetvnfs
 	ln -s transporthandler rootfs/sbin/wwgetscript
 	ln -s transporthandler rootfs/sbin/wwgetnodeconfig
 	ln -s transporthandler rootfs/sbin/wwgetfiles
 
+# Set timestamps of links and directories in archives to fixed value for build repoducibility
 initramfs.cpio: rootfs
 	install -m 644 $(srcdir)/devs.cpio initramfs.cpio
-	cd rootfs/; find . | cpio -o -H newc -A -F ../initramfs.cpio
+	find rootfs/ -type d -o -type l | xargs touch -h -r devs.cpio
+	cd rootfs/; find . | cpio -o -H newc --reproducible -A -F ../initramfs.cpio
 
 install-data-local: initramfs.cpio
 	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/

--- a/provision/initramfs/capabilities/provision-adhoc/Makefile.am
+++ b/provision/initramfs/capabilities/provision-adhoc/Makefile.am
@@ -4,16 +4,18 @@ MAINTAINERCLEANFILES = Makefile.in
 
 MACHINE:=$(shell uname -m)
 
+# Preserve time stamps of archived files for build reproducibility
 rootfs:
 	rm -rf rootfs
 	mkdir -p rootfs/warewulf/provision/
 	@ for i in $(METHODSCRIPTS); do \
 		echo "install -m 755 $$i rootfs/warewulf/provision/$$i" ; \
-		install -m 755 $(srcdir)/$$i rootfs/warewulf/provision/$$i; \
+		install -p -m 755 $(srcdir)/$$i rootfs/warewulf/provision/$$i; \
 	done
 
 capability.cpio: rootfs
-	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
+	find rootfs/ -type d | xargs touch -r $(word 1,$(METHODSCRIPTS));
+	cd rootfs/; find . | cpio -o -H newc --reproducible -F ../capability.cpio
 
 install-data-local: capability.cpio
 	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities

--- a/provision/initramfs/capabilities/provision-files/Makefile.am
+++ b/provision/initramfs/capabilities/provision-files/Makefile.am
@@ -4,16 +4,18 @@ MAINTAINERCLEANFILES = Makefile.in
 
 MACHINE:=$(shell uname -m)
 
+# Preserve time stamps of archived files for build reproducibility
 rootfs:
 	rm -rf rootfs
 	mkdir -p rootfs/warewulf/provision/
 	@ for i in $(METHODSCRIPTS); do \
 		echo "install -m 755 $$i rootfs/warewulf/provision/$$i" ; \
-		install -m 755 $(srcdir)/$$i rootfs/warewulf/provision/$$i; \
+		install -p -m 755 $(srcdir)/$$i rootfs/warewulf/provision/$$i; \
 	done
 
 capability.cpio: rootfs
-	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
+	find rootfs/ -type d | xargs touch -r $(word 1,$(METHODSCRIPTS));
+	cd rootfs/; find . | cpio -o -H newc --reproducible -F ../capability.cpio
 
 install-data-local: capability.cpio
 	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities

--- a/provision/initramfs/capabilities/provision-selinux/Makefile.am
+++ b/provision/initramfs/capabilities/provision-selinux/Makefile.am
@@ -4,16 +4,18 @@ MAINTAINERCLEANFILES = Makefile.in
 
 MACHINE:=$(shell uname -m)
 
+# Preserve time stamps of archived files for build reproducibility
 rootfs:
 	rm -rf rootfs
 	mkdir -p rootfs/warewulf/provision/
 	@ for i in $(METHODSCRIPTS); do \
 		echo "install -m 755 $$i rootfs/warewulf/provision/$$i" ; \
-		install -m 755 $(srcdir)/$$i rootfs/warewulf/provision/$$i; \
+		install -p -m 755 $(srcdir)/$$i rootfs/warewulf/provision/$$i; \
 	done
 
 capability.cpio: rootfs
-	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
+	find rootfs/ -type d | xargs touch -r $(word 1,$(METHODSCRIPTS));
+	cd rootfs/; find . | cpio -o -H newc --reproducible -F ../capability.cpio
 
 install-data-local: capability.cpio
 	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities

--- a/provision/initramfs/capabilities/provision-unionfs/Makefile.am
+++ b/provision/initramfs/capabilities/provision-unionfs/Makefile.am
@@ -18,11 +18,11 @@ unionfs:
 	@ if [ ! -f "_work/unionfs-fuse/unionfs-fuse-$(UNIONFS_VERSION)/src/unionfs" ]; then \
 	    echo "Building unionfs-fuse" ;\
 	    $(MAKE) -C _work/unionfs-fuse/unionfs-fuse-$(UNIONFS_VERSION) ;\
+	    touch -r ../devs.cpio _work/unionfs-fuse/unionfs-fuse-$(UNIONFS_VERSION)/src/unionfs
 	fi
 	@ if [ ! -f "unionfs" ]; then \
 	    cp -a _work/unionfs-fuse/unionfs-fuse-$(UNIONFS_VERSION)/src/unionfs unionfs ;\
 	fi
-
 
 rootfs: unionfs
 	rm -rf rootfs
@@ -35,8 +35,10 @@ rootfs: unionfs
 	find rootfs -type f -perm -o+x  -print | xargs ldd | grep "=>" | awk '{print $$3}' | grep "^/" | sort | uniq | while read i; do cp -L --parents $$i rootfs/; done
 	find rootfs -type f -perm -o+x -print | xargs strip -g
 
+# Preserve time stamps of archived files for build reproducibility
 capability.cpio: rootfs
-	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
+	find rootfs/ -type d | xargs touch -r unionfs;
+	cd rootfs/; find . | cpio -o -H newc --reproducible -F ../capability.cpio
 
 install-data-local: capability.cpio
 	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities

--- a/provision/initramfs/capabilities/provision-vnfs/Makefile.am
+++ b/provision/initramfs/capabilities/provision-vnfs/Makefile.am
@@ -9,11 +9,13 @@ rootfs:
 	mkdir -p rootfs/warewulf/provision/
 	@ for i in $(METHODSCRIPTS); do \
 		echo "install -m 755 $$i rootfs/warewulf/provision/$$i" ; \
-		install -m 755 $(srcdir)/$$i rootfs/warewulf/provision/$$i; \
+		install -p -m 755 $(srcdir)/$$i rootfs/warewulf/provision/$$i; \
 	done
 
+# Preserve time stamps of archived files for build reproducibility
 capability.cpio: rootfs
-	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
+	find rootfs/ -type d | xargs touch -r $(word 1,$(METHODSCRIPTS));
+	cd rootfs/; find . | cpio -o -H newc --reproducible -F ../capability.cpio
 
 install-data-local: capability.cpio
 	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities

--- a/provision/initramfs/capabilities/setup-filesystems/Makefile.am
+++ b/provision/initramfs/capabilities/setup-filesystems/Makefile.am
@@ -9,11 +9,13 @@ rootfs:
 	mkdir -p rootfs/warewulf/provision/
 	@ for i in $(METHODSCRIPTS); do \
 		echo "install -m 755 $$i rootfs/warewulf/provision/$$i" ; \
-		install -m 755 $(srcdir)/$$i rootfs/warewulf/provision/$$i; \
+		install -p -m 755 $(srcdir)/$$i rootfs/warewulf/provision/$$i; \
 	done
 
+# Preserve time stamps of archived files for build reproducibility
 capability.cpio: rootfs
-	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
+	find rootfs/ -type d | xargs touch -r $(word 1,$(METHODSCRIPTS));
+	cd rootfs/; find . | cpio -o -H newc --reproducible -F ../capability.cpio
 
 install-data-local: capability.cpio
 	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities

--- a/provision/initramfs/capabilities/transport-http/Makefile.am
+++ b/provision/initramfs/capabilities/transport-http/Makefile.am
@@ -12,11 +12,13 @@ rootfs:
 	mkdir -p rootfs/warewulf/transports/$(TRANSPORT_NAME)
 	@ for i in $(METHODSCRIPTS); do \
 		echo "install -m 755 $$i rootfs/warewulf/transports/$(TRANSPORT_NAME)/$$i" ; \
-		install -m 755 $(srcdir)/$$i rootfs/warewulf/transports/$(TRANSPORT_NAME)/$$i; \
+		install -p -m 755 $(srcdir)/$$i rootfs/warewulf/transports/$(TRANSPORT_NAME)/$$i; \
 	done
 
+# Preserve time stamps of archived files for build reproducibility
 capability.cpio: rootfs
-	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
+	find rootfs/ -type d | xargs touch -r $(word 1,$(METHODSCRIPTS));
+	cd rootfs/; find . | cpio -o -H newc --reproducible -F ../capability.cpio
 
 install-data-local: capability.cpio
 	install -d -m 755 $(DESTDIR)/$(WAREWULF_STATEDIR)/warewulf/initramfs/$(MACHINE)/capabilities

--- a/provision/initramfs/capabilities/transport-https/Makefile.am
+++ b/provision/initramfs/capabilities/transport-https/Makefile.am
@@ -15,6 +15,7 @@ rootfs:
 		install -m 755 $(srcdir)/$$i rootfs/warewulf/transports/$(TRANSPORT_NAME)/$$i; \
 	done
 
+# Preserve time stamps of archived files for build reproducibility
 capability.cpio: rootfs
 	cd rootfs/; find . | cpio -o -H newc -F ../capability.cpio
 


### PR DESCRIPTION
This pull request supersedes pull request #323:
There is a project under way to convince and help software projects to make their builds reproducible:
 https://reproducible-builds.org/
openSUSE Factory is participating in this by attempting to make the entire build reproducible: https://en.opensuse.org/openSUSE:Reproducible_Builds. If packages contain files that may change between builds, these packages require changes. Since warewulf3 includes CPIO archives of an initramdisk there is a bit more effort involved in making the build reproducible: not only the file content but also the time stamps of the files in these archives matter. Moreover, cpio needs to be run with the option `--reproducible`.
Out tests have shown that by setting the access and modification time to a fixed reference value using touch is sufficient to make the resulting CPIO archives reproducible.